### PR TITLE
Handle source set outputs being added to the compile configuration

### DIFF
--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The `revapi` task will handle the case where the outputs of source
+    sets are added to configurations that Revapi consumes.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/8

--- a/src/main/java/com/palantir/gradle/revapi/RevapiJavaTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiJavaTask.java
@@ -127,7 +127,10 @@ public class RevapiJavaTask extends DefaultTask {
 
     private API newApi() {
         List<FileArchive> newApiJar = toFileArchives(newApiJars);
-        List<FileArchive> newApiDependencies = toFileArchives(newApiDependencyJars.get().resolve());
+        List<FileArchive> newApiDependencies = toFileArchives(newApiDependencyJars.get().resolve()
+                .stream()
+                .filter(File::isFile)
+                .collect(Collectors.toSet()));
 
         return API.builder()
                 .addArchives(newApiJar)

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -141,6 +141,37 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingResolutionFailure("root-project")
     }
 
+    def 'handles the output of extra source sets being added to compile configuration'() {
+        when:
+        buildFile << """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+            apply plugin: 'java'
+            
+            sourceSets {
+                extraStuff
+            }
+            
+            dependencies {
+                compile sourceSets.extraStuff.output
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            revapi {
+                oldGroup = 'org.revapi'
+                oldName = 'revapi'
+                oldVersion = '0.11.1'
+            }
+        """.stripIndent()
+
+        rootProjectNameIs("root-project")
+
+        then:
+        runRevapiExpectingToFindDifferences("root-project")
+    }
+
     private File rootProjectNameIs(String projectName) {
         settingsFile << "rootProject.name = '${projectName}'"
     }


### PR DESCRIPTION
## Before this PR
The `revapi` task fails on an internal project that adds the outputs of a sourceset to the `api` configuration.

## After this PR
==COMMIT_MSG==
The `revapi` task will handle the case where the outputs of source sets are added to configurations that Revapi consumes.
==COMMIT_MSG==