### PR TITLE
Better names for config classes

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
+++ b/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
@@ -17,13 +17,13 @@
 package com.palantir.gradle.revapi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.palantir.gradle.revapi.config.RevapiConfig;
+import com.palantir.gradle.revapi.config.GradleRevapiConfig;
 import java.io.File;
 import java.io.IOException;
 import java.util.function.UnaryOperator;
 
 final class ConfigManager {
-    private static final ObjectMapper OBJECT_MAPPER = RevapiConfig.newRecommendedObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newRecommendedObjectMapper();
 
     // This lock is overly broad, but it is very hard to share the lock between tasks without having a root project
     // application managing everything.
@@ -35,29 +35,29 @@ final class ConfigManager {
         this.configFile = configFile;
     }
 
-    public void modifyConfigFile(UnaryOperator<RevapiConfig> transformer) {
+    public void modifyConfigFile(UnaryOperator<GradleRevapiConfig> transformer) {
         synchronized (CONFIG_FILE_LOCK) {
-            RevapiConfig oldRevapiConfig = fromFileOrEmptyIfDoesNotExist();
-            RevapiConfig newRevapiConfig = transformer.apply(oldRevapiConfig);
+            GradleRevapiConfig oldGradleRevapiConfig = fromFileOrEmptyIfDoesNotExist();
+            GradleRevapiConfig newGradleRevapiConfig = transformer.apply(oldGradleRevapiConfig);
 
             configFile.getParentFile().mkdirs();
 
             try {
-                OBJECT_MAPPER.writeValue(configFile, newRevapiConfig);
+                OBJECT_MAPPER.writeValue(configFile, newGradleRevapiConfig);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to modify revapi config file: " + configFile, e);
             }
         }
     }
 
-    public RevapiConfig fromFileOrEmptyIfDoesNotExist() {
+    public GradleRevapiConfig fromFileOrEmptyIfDoesNotExist() {
         if (!configFile.exists()) {
-            return RevapiConfig.empty();
+            return GradleRevapiConfig.empty();
         }
 
         try {
             synchronized (CONFIG_FILE_LOCK) {
-                return OBJECT_MAPPER.readValue(configFile, RevapiConfig.class);
+                return OBJECT_MAPPER.readValue(configFile, GradleRevapiConfig.class);
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to read revapi config file: " + configFile, e);

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
@@ -59,7 +59,7 @@ public class RevapiAcceptAllBreaksTask extends RevapiJavaTask {
 
         File breaksPath = Files.createTempFile("reavpi-breaks", ".yml").toFile();
 
-        runRevapi(RevapiJsonConfig.empty()
+        runRevapi(RevapiConfig.empty()
                 .withTextReporter("gradle-revapi-accept-breaks.ftl", breaksPath));
 
         List<AcceptedBreak> rawAcceptedBreaks =

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
@@ -19,9 +19,9 @@ package com.palantir.gradle.revapi;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.gradle.revapi.config.AcceptedBreak;
+import com.palantir.gradle.revapi.config.GradleRevapiConfig;
 import com.palantir.gradle.revapi.config.GroupNameVersion;
 import com.palantir.gradle.revapi.config.Justification;
-import com.palantir.gradle.revapi.config.RevapiConfig;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
@@ -33,7 +33,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 public class RevapiAcceptAllBreaksTask extends RevapiJavaTask {
-    private static final ObjectMapper OBJECT_MAPPER = RevapiConfig.newRecommendedObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newRecommendedObjectMapper();
     public static final String JUSTIFICATION = "justification";
 
     private final Property<GroupNameVersion> oldGroupNameVersion =

--- a/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
@@ -39,7 +39,7 @@ import org.revapi.API;
 import org.revapi.Archive;
 
 @Value.Immutable
-abstract class RevapiJsonConfig {
+abstract class RevapiConfig {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
             .registerModule(new Jdk8Module());
 
@@ -49,7 +49,7 @@ abstract class RevapiJsonConfig {
         return config().toString();
     }
 
-    public RevapiJsonConfig withTextReporter(String templateName, File outputPath) {
+    public RevapiConfig withTextReporter(String templateName, File outputPath) {
         return withExtension("revapi.reporter.text", OBJECT_MAPPER.createObjectNode()
                 .put("minSeverity", "BREAKING")
                 .put("template", templateName)
@@ -57,11 +57,11 @@ abstract class RevapiJsonConfig {
                 .put("append", false));
     }
 
-    public RevapiJsonConfig withIgnoredBreaks(Set<AcceptedBreak> acceptedBreaks) {
+    public RevapiConfig withIgnoredBreaks(Set<AcceptedBreak> acceptedBreaks) {
         return withExtension("revapi.ignore", OBJECT_MAPPER.convertValue(acceptedBreaks, ArrayNode.class));
     }
 
-    private RevapiJsonConfig withExtension(String extensionId, JsonNode configuration) {
+    private RevapiConfig withExtension(String extensionId, JsonNode configuration) {
         JsonNode extension = OBJECT_MAPPER.createObjectNode()
                 .put("extension", extensionId)
                 .set("configuration", configuration);
@@ -72,14 +72,14 @@ abstract class RevapiJsonConfig {
                 .build());
     }
 
-    public RevapiJsonConfig mergeWith(RevapiJsonConfig other) {
+    public RevapiConfig mergeWith(RevapiConfig other) {
         return new Builder()
                 .from(this)
                 .addAllConfig(other.config())
                 .build();
     }
 
-    public static RevapiJsonConfig defaults(API oldApi, API newApi) {
+    public static RevapiConfig defaults(API oldApi, API newApi) {
         try {
             String template = Resources.toString(
                     Resources.getResource(
@@ -96,18 +96,18 @@ abstract class RevapiJsonConfig {
         }
     }
 
-    public static RevapiJsonConfig mergeAll(RevapiJsonConfig... revapiJsonConfigs) {
-        return Arrays.stream(revapiJsonConfigs)
-                .reduce(empty(), RevapiJsonConfig::mergeWith);
+    public static RevapiConfig mergeAll(RevapiConfig... revapiConfigs) {
+        return Arrays.stream(revapiConfigs)
+                .reduce(empty(), RevapiConfig::mergeWith);
     }
 
-    static final class Builder extends ImmutableRevapiJsonConfig.Builder { }
+    static final class Builder extends ImmutableRevapiConfig.Builder { }
 
-    public static RevapiJsonConfig empty() {
+    public static RevapiConfig empty() {
         return fromJsonNodes(Collections.emptyList());
     }
 
-    private static RevapiJsonConfig fromString(String configJson) {
+    private static RevapiConfig fromString(String configJson) {
         try {
             return fromJsonNodes(OBJECT_MAPPER.readValue(configJson, new TypeReference<List<JsonNode>>() {}));
         } catch (IOException e) {
@@ -115,7 +115,7 @@ abstract class RevapiJsonConfig {
         }
     }
 
-    private static RevapiJsonConfig fromJsonNodes(List<JsonNode> jsonNodes) {
+    private static RevapiConfig fromJsonNodes(List<JsonNode> jsonNodes) {
         return new Builder()
                 .config(jsonNodes)
                 .build();

--- a/src/main/java/com/palantir/gradle/revapi/RevapiJavaTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiJavaTask.java
@@ -64,7 +64,7 @@ public abstract class RevapiJavaTask extends DefaultTask {
         return newApiJars;
     }
 
-    protected final void runRevapi(RevapiJsonConfig taskSpecificConfigJson) throws Exception {
+    protected final void runRevapi(RevapiConfig taskSpecificConfigJson) throws Exception {
         API oldApi = oldApi();
         API newApi = newApi();
 
@@ -77,8 +77,8 @@ public abstract class RevapiJavaTask extends DefaultTask {
                 .withReporters(TextReporter.class)
                 .build();
 
-        String revapiJsonConfig = RevapiJsonConfig.mergeAll(
-                RevapiJsonConfig.defaults(oldApi, newApi),
+        String revapiJsonConfig = RevapiConfig.mergeAll(
+                RevapiConfig.defaults(oldApi, newApi),
                 taskSpecificConfigJson,
                 revapiIgnores()).configAsString();
 
@@ -92,12 +92,12 @@ public abstract class RevapiJavaTask extends DefaultTask {
         }
     }
 
-    private RevapiJsonConfig revapiIgnores() {
+    private RevapiConfig revapiIgnores() {
         Set<AcceptedBreak> acceptedBreaks = configManager.get()
                 .fromFileOrEmptyIfDoesNotExist()
                 .acceptedBreaksFor(getExtension().oldGroupNameVersion());
 
-        return RevapiJsonConfig.empty()
+        return RevapiConfig.empty()
                 .withIgnoredBreaks(acceptedBreaks);
     }
 

--- a/src/main/java/com/palantir/gradle/revapi/RevapiReportTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiReportTask.java
@@ -57,7 +57,7 @@ public class RevapiReportTask extends RevapiJavaTask {
         Path textOutputTemplate = templateWithDifferenceTemplateAndWriteToFile(
                 "gradle-revapi-text-template.ftl", differenceTemplate);
 
-        runRevapi(RevapiJsonConfig.empty()
+        runRevapi(RevapiConfig.empty()
                 .withTextReporter(junitTemplate.toString(), junitOutput())
                 .withTextReporter(textOutputTemplate.toString(), textOutputPath.toFile()));
 

--- a/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonDeserialize(as = ImmutableRevapiConfig.class)
-public abstract class RevapiConfig {
+@JsonDeserialize(as = ImmutableGradleRevapiConfig.class)
+public abstract class GradleRevapiConfig {
     protected abstract Map<GroupNameVersion, String> versionOverrides();
     protected abstract Map<Version, PerProjectAcceptedBreaks> acceptedBreaks();
 
@@ -39,8 +39,8 @@ public abstract class RevapiConfig {
         return Optional.ofNullable(versionOverrides().get(groupNameVersion));
     }
 
-    public final RevapiConfig addVersionOverride(GroupNameVersion groupNameVersion, String versionOverride) {
-        return ImmutableRevapiConfig.builder()
+    public final GradleRevapiConfig addVersionOverride(GroupNameVersion groupNameVersion, String versionOverride) {
+        return ImmutableGradleRevapiConfig.builder()
                 .from(this)
                 .putVersionOverrides(groupNameVersion, versionOverride)
                 .build();
@@ -52,7 +52,7 @@ public abstract class RevapiConfig {
                 .orElseGet(Collections::emptySet);
     }
 
-    public final RevapiConfig addAcceptedBreaks(
+    public final GradleRevapiConfig addAcceptedBreaks(
             GroupNameVersion groupNameVersion,
             Set<AcceptedBreak> acceptedBreaks) {
 
@@ -66,14 +66,14 @@ public abstract class RevapiConfig {
         Map<Version, PerProjectAcceptedBreaks> newAcceptedBreaks = new HashMap<>(acceptedBreaks());
         newAcceptedBreaks.put(groupNameVersion.version(), newPerProjectAcceptedBreaks);
 
-        return ImmutableRevapiConfig.builder()
+        return ImmutableGradleRevapiConfig.builder()
                 .from(this)
                 .acceptedBreaks(newAcceptedBreaks)
                 .build();
     }
 
-    public static RevapiConfig empty() {
-        return ImmutableRevapiConfig.builder().build();
+    public static GradleRevapiConfig empty() {
+        return ImmutableGradleRevapiConfig.builder().build();
     }
 
     public static ObjectMapper newRecommendedObjectMapper() {

--- a/src/test/java/com/palantir/gradle/revapi/ConfigManagerTest.java
+++ b/src/test/java/com/palantir/gradle/revapi/ConfigManagerTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.gradle.revapi.config.AcceptedBreak;
+import com.palantir.gradle.revapi.config.GradleRevapiConfig;
 import com.palantir.gradle.revapi.config.GroupNameVersion;
-import com.palantir.gradle.revapi.config.RevapiConfig;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -42,11 +42,11 @@ class ConfigManagerTest {
     void withConfigFile_returns_empty_config_if_there_is_no_file() {
         File nonExistentFile1 = new File(tempDir, "does-not-exist");
         ConfigManager configManager = new ConfigManager(nonExistentFile1);
-        UnaryOperator<RevapiConfig> transformer = identityFunction();
+        UnaryOperator<GradleRevapiConfig> transformer = identityFunction();
 
         configManager.modifyConfigFile(transformer);
 
-        verify(transformer).apply(RevapiConfig.empty());
+        verify(transformer).apply(GradleRevapiConfig.empty());
     }
 
     @Test
@@ -120,13 +120,13 @@ class ConfigManagerTest {
                 "  foo:bar:3.12: \"1.0\"")
                 .getBytes(StandardCharsets.UTF_8));
 
-        RevapiConfig revapiConfig = configManager.fromFileOrEmptyIfDoesNotExist();
+        GradleRevapiConfig gradleRevapiConfig = configManager.fromFileOrEmptyIfDoesNotExist();
 
-        assertThat(revapiConfig.versionOverrideFor(GroupNameVersion.fromString("foo:bar:3.12"))).hasValue("1.0");
+        assertThat(gradleRevapiConfig.versionOverrideFor(GroupNameVersion.fromString("foo:bar:3.12"))).hasValue("1.0");
     }
 
-    private UnaryOperator<RevapiConfig> identityFunction() {
-        UnaryOperator<RevapiConfig> transformer = mock(UnaryOperator.class);
+    private UnaryOperator<GradleRevapiConfig> identityFunction() {
+        UnaryOperator<GradleRevapiConfig> transformer = mock(UnaryOperator.class);
         when(transformer.apply(any())).thenAnswer(invocation -> invocation.getArgument(0));
         return transformer;
     }


### PR DESCRIPTION
## Before this PR
`RevapiConfig` referred to the gradle plugin config files.
`RevapiJsonConfig` referred to the actual config used by Revapi.

This is confusing.

## After this PR
Now named `GradleRevapiConfig` and `RevapiConfig` to be less confusing.

