### PR TITLE
No longer use statics for config file locking - instead use root plugin application

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
+++ b/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
@@ -25,10 +25,7 @@ import java.util.function.UnaryOperator;
 final class ConfigManager {
     private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newRecommendedObjectMapper();
 
-    // This lock is overly broad, but it is very hard to share the lock between tasks without having a root project
-    // application managing everything.
-    private static final Object CONFIG_FILE_LOCK = new Object();
-
+    private final Object configFileLock = new Object();
     private final File configFile;
 
     ConfigManager(File configFile) {
@@ -36,7 +33,7 @@ final class ConfigManager {
     }
 
     public void modifyConfigFile(UnaryOperator<GradleRevapiConfig> transformer) {
-        synchronized (CONFIG_FILE_LOCK) {
+        synchronized (configFileLock) {
             GradleRevapiConfig oldGradleRevapiConfig = fromFileOrEmptyIfDoesNotExist();
             GradleRevapiConfig newGradleRevapiConfig = transformer.apply(oldGradleRevapiConfig);
 
@@ -56,7 +53,7 @@ final class ConfigManager {
         }
 
         try {
-            synchronized (CONFIG_FILE_LOCK) {
+            synchronized (configFileLock) {
                 return OBJECT_MAPPER.readValue(configFile, GradleRevapiConfig.class);
             }
         } catch (IOException e) {

--- a/src/main/java/com/palantir/gradle/revapi/RevapiGlobalConfigPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiGlobalConfigPlugin.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.revapi;
+
+import java.io.File;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public final class RevapiGlobalConfigPlugin implements Plugin<Project> {
+    private ConfigManager configManager;
+
+    @Override
+    public void apply(Project project) {
+        if (project != project.getRootProject()) {
+            throw new IllegalStateException(
+                    RevapiGlobalConfigPlugin.class.getSimpleName()
+                    + " can only be applied to the root project");
+        }
+
+        configManager = new ConfigManager(new File(project.getRootDir(), ".palantir/revapi.yml"));
+    }
+
+    public ConfigManager configManager() {
+        return configManager;
+    }
+}

--- a/src/main/java/com/palantir/gradle/revapi/RevapiGlobalConfigPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiGlobalConfigPlugin.java
@@ -20,7 +20,7 @@ import java.io.File;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-public final class RevapiGlobalConfigPlugin implements Plugin<Project> {
+final class RevapiGlobalConfigPlugin implements Plugin<Project> {
     private ConfigManager configManager;
 
     @Override
@@ -34,7 +34,7 @@ public final class RevapiGlobalConfigPlugin implements Plugin<Project> {
         configManager = new ConfigManager(new File(project.getRootDir(), ".palantir/revapi.yml"));
     }
 
-    public ConfigManager configManager() {
+    ConfigManager configManager() {
         return configManager;
     }
 }

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.revapi;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.File;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
@@ -41,13 +40,16 @@ public final class RevapiPlugin implements Plugin<Project> {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
         project.getPluginManager().apply(JavaPlugin.class);
 
+        ConfigManager configManager = project.getRootProject()
+                .getPlugins()
+                .apply(RevapiGlobalConfigPlugin.class)
+                .configManager();
+
         RevapiExtension extension = project.getExtensions().create("revapi", RevapiExtension.class, project);
 
         Configuration revapiNewApi = project.getConfigurations().create("revapiNewApi", conf -> {
             conf.extendsFrom(project.getConfigurations().getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME));
         });
-
-        ConfigManager configManager = new ConfigManager(configFile(project));
 
         TaskProvider<RevapiReportTask> revapiTask = project.getTasks().register("revapi", RevapiReportTask.class);
 
@@ -95,9 +97,5 @@ public final class RevapiPlugin implements Plugin<Project> {
                         .matching(jar -> jar.getName().equals(JavaPlugin.JAR_TASK_NAME))
                         .stream())
                 .collect(Collectors.toSet()));
-    }
-
-    private static File configFile(Project project) {
-        return new File(project.getRootDir(), ".palantir/revapi.yml");
     }
 }


### PR DESCRIPTION
## Before this PR
We make this `ConfigManager` object everywhere that has a static lock inside, which is a little complicated. This static state is shared between tests :(

## After this PR
We use a plugin that is applied to the root project as a "per gradle invocataion singleton" rather than a "per jvm singleton".

