### PR TITLE
Exclude scala classes

### DIFF
--- a/changelog/@unreleased/pr-42.v2.yml
+++ b/changelog/@unreleased/pr-42.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Scala classes are ignored by default by `gradle-revapi`.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/42

--- a/src/main/resources/revapi-configuration.json
+++ b/src/main/resources/revapi-configuration.json
@@ -2,7 +2,13 @@
   {
     "extension": "revapi.java",
     "configuration": {
-      "reportUsesFor": []
+      "reportUsesFor": [],
+      "filter": {
+        "classes": {
+          "regex": true,
+          "exclude": [".*\\$$"]
+        }
+      }
     }
   },
   {
@@ -11,6 +17,13 @@
       "archives" : {
         "include" : ["{{ARCHIVE_INCLUDE_REGEXES}}"]
       }
+    }
+  },
+  {
+    "extension": "revapi.java.filter.annotated",
+    "configuration": {
+      "regex": true,
+      "exclude": ["(?s)@scala\\.reflect\\.ScalaSignature.*"]
     }
   },
   {

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -266,6 +266,27 @@ class RevapiSpec extends IntegrationSpec {
 
     }
 
+    def 'ignores scala classes'() {
+        when:
+        buildFile << """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            revapi {
+                oldGroup = 'com.twitter'
+                oldName = 'chill-avro_2.12'
+                oldVersion = '0.9.3'
+            }
+        """.stripIndent()
+
+        then:
+        runTasksSuccessfully("revapi")
+    }
+
     private File rootProjectNameIs(String projectName) {
         settingsFile << "rootProject.name = '${projectName}'"
     }


### PR DESCRIPTION
## Before this PR
If a jar has Scala classes, revapi will spuriously report loads of breaking since it doesn't understand Scala private methods etc.

## After this PR
==COMMIT_MSG==
Scala classes are ignored by default by `gradle-revapi`.
==COMMIT_MSG==

## Possible downsides?
We search for Scala classes by seeing if it has the annotation `@scala.reflect.ScalaSignature` or if the class ends in `$`. The former seems very safe to check, the latter is a bit more risky, however I couldn't find a way to detect [the classes made by the `object` syntax](https://stackoverflow.com/a/30732256/139766) in Scala in any better way :(.

