### PR TITLE
Fix parsing problems when running `revapiAcceptAllBreaks` task

### DIFF
--- a/changelog/@unreleased/pr-50.v2.yml
+++ b/changelog/@unreleased/pr-50.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`revapiAcceptAllBreaks` will work on classes that have a string representation
+    including `, ` or starting with `@interface`.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/50

--- a/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
+++ b/src/main/java/com/palantir/gradle/revapi/ConfigManager.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.function.UnaryOperator;
 
 final class ConfigManager {
-    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newRecommendedObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newYamlObjectMapper();
 
     // This lock is overly broad, but it is very hard to share the lock between tasks without having a root project
     // application managing everything.

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAcceptAllBreaksTask.java
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 public class RevapiAcceptAllBreaksTask extends RevapiJavaTask {
-    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newRecommendedObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = GradleRevapiConfig.newJsonObjectMapper();
     public static final String JUSTIFICATION = "justification";
 
     private final Property<GroupNameVersion> oldGroupNameVersion =
@@ -60,7 +60,7 @@ public class RevapiAcceptAllBreaksTask extends RevapiJavaTask {
 
         Path tempDir = getProject().getLayout().getBuildDirectory().dir("tmp").get().getAsFile().toPath();
 
-        File breaksPath = Files.createTempFile(tempDir, "revapi-breaks", ".yml").toFile();
+        File breaksPath = Files.createTempFile(tempDir, "revapi-breaks", ".json").toFile();
 
         runRevapi(RevapiConfig.empty()
                 .withTextReporter("gradle-revapi-accept-breaks.ftl", breaksPath));

--- a/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.revapi.config;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -76,10 +77,18 @@ public abstract class GradleRevapiConfig {
         return ImmutableGradleRevapiConfig.builder().build();
     }
 
-    public static ObjectMapper newRecommendedObjectMapper() {
-        return new ObjectMapper(
-                new YAMLFactory()
-                        .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER))
+    public static ObjectMapper newYamlObjectMapper() {
+        return configureObjectMapper(new ObjectMapper(new YAMLFactory()
+                .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)));
+    }
+
+    public static ObjectMapper newJsonObjectMapper() {
+        return configureObjectMapper(new ObjectMapper())
+                .enable(JsonParser.Feature.ALLOW_TRAILING_COMMA);
+    }
+
+    private static ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
+        return objectMapper
                 .registerModule(new GuavaModule())
                 .registerModule(new Jdk8Module());
     }

--- a/src/main/resources/META-INF/gradle-revapi-accept-breaks.ftl
+++ b/src/main/resources/META-INF/gradle-revapi-accept-breaks.ftl
@@ -5,8 +5,8 @@
 <#list report.differences as diff>
  {
   "code": "${diff.code}",
-  "old": ${("\"" + report.oldElement + "\"")!"null"},
-  "new": ${("\"" + report.newElement + "\"")!"null"},
+  "old": ${("\"" + report.oldElement.toString()?json_string + "\"")!"null"},
+  "new": ${("\"" + report.newElement.toString()?json_string + "\"")!"null"},
   "justification": "needs justification"
  },
 </#list>

--- a/src/main/resources/META-INF/gradle-revapi-accept-breaks.ftl
+++ b/src/main/resources/META-INF/gradle-revapi-accept-breaks.ftl
@@ -4,10 +4,10 @@
 <#list reports as report>
 <#list report.differences as diff>
  {
-  "code": ${diff.code},
-  "old": ${report.oldElement!"null"},
-  "new": ${report.newElement!"null"},
-  "justification": "<needs justification>",
+  "code": "${diff.code}",
+  "old": ${("\"" + report.oldElement + "\"")!"null"},
+  "new": ${("\"" + report.newElement + "\"")!"null"},
+  "justification": "needs justification"
  },
 </#list>
 </#list>

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -225,9 +225,9 @@ class RevapiSpec extends IntegrationSpec {
             }
             
             revapi {
-                oldGroup = 'org.assertj'
-                oldName = 'assertj-core'
-                oldVersion = '3.13.2'
+                oldGroup = 'junit'
+                oldName = 'junit'
+                oldVersion = '4.12'
             }
         """.stripIndent()
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -225,9 +225,9 @@ class RevapiSpec extends IntegrationSpec {
             }
             
             revapi {
-                oldGroup = 'org.revapi'
-                oldName = 'revapi'
-                oldVersion = '0.11.1'
+                oldGroup = 'org.assertj'
+                oldName = 'assertj-core'
+                oldVersion = '3.13.2'
             }
         """.stripIndent()
 


### PR DESCRIPTION
## Before this PR
When running the `revapiAcceptAllBreaks` task, it would fail if there was a class identifier that had a `, ` in, such as a class with more than one generic parameter.

## After this PR
==COMMIT_MSG==
`revapiAcceptAllBreaks` will work on classes that have a string representation including `, ` or starting with `@interface`.
==COMMIT_MSG==

