### PR TITLE
Ignore magically added groovy methods

### DIFF
--- a/changelog/@unreleased/pr-66.v2.yml
+++ b/changelog/@unreleased/pr-66.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`gradle-revapi` will not spuriously identify the addition of abstract
+    methods from `groovy.lang.GroovyObject` as breaks.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/66

--- a/src/main/resources/revapi-configuration.json
+++ b/src/main/resources/revapi-configuration.json
@@ -29,9 +29,15 @@
   {
     "extension": "revapi.ignore",
     "configuration": [
-      { "code" : "java.class.nonPublicPartOfAPI" },
-      { "code" : "java.class.externalClassNoLongerExposedInAPI" },
-      { "code" : "java.class.externalClassExposedInAPI" }
+      { "code": "java.class.nonPublicPartOfAPI" },
+      { "code": "java.class.externalClassNoLongerExposedInAPI" },
+      { "code": "java.class.externalClassExposedInAPI" },
+      {
+        "regex": true,
+        "code": "java.method.abstractMethodAdded",
+        "new": ".*groovy.lang.GroovyObject::.*"
+      }
+
     ]
   }
 ]

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -346,15 +346,12 @@ class RevapiSpec extends IntegrationSpec {
             }
         """.stripIndent()
 
-        def groovyClassPath = 'src/main/groovy/foo/Foo.groovy'
-        def groovyClassSource = '''
+        writeToFile 'src/main/groovy/foo/Foo.groovy', '''
             package foo
             class Foo {
                 String someProperty
             }
         '''.stripIndent()
-
-        writeToFile groovyClassPath, groovyClassSource
 
         println runTasksSuccessfully("publishToMavenLocal").standardOutput
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -44,9 +44,7 @@ class RevapiSpec extends IntegrationSpec {
 
         rootProjectNameIs("root-project")
 
-        def file = new File(projectDir, "src/main/java/foo/Foo.java")
-        file.getParentFile().mkdirs()
-        file << '''
+        writeToFile 'src/main/java/foo/Foo.java', '''
             import one.util.streamex.StreamEx;
 
             public interface Foo {
@@ -122,9 +120,8 @@ class RevapiSpec extends IntegrationSpec {
 
         rootProjectNameIs(revapi)
 
-        def file = new File(projectDir, "src/main/java/foo/Foo.java")
-        file.getParentFile().mkdirs()
-        file << '''
+
+        writeToFile 'src/main/java/foo/Foo.java', '''
             public interface Foo {
                 String lol();
             }
@@ -357,7 +354,7 @@ class RevapiSpec extends IntegrationSpec {
             }
         '''.stripIndent()
 
-        writeToFile projectDir, groovyClassPath, groovyClassSource
+        writeToFile groovyClassPath, groovyClassSource
 
         println runTasksSuccessfully("publishToMavenLocal").standardOutput
 
@@ -365,8 +362,8 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
-    public void writeToFile(File dir, String filename, String content) {
-        def file = new File(dir, filename)
+    private void writeToFile(String filename, String content) {
+        def file = new File(projectDir, filename)
         file.getParentFile().mkdirs()
         file << content
     }


### PR DESCRIPTION
## Before this PR
See #65. Groovy would add `implements GroovyObject` to the bytecode of groovy class files, resulting in false positives when comparing between the same class files, somehow:

```
java.method.abstractMethodAdded: Abstract method was added.

old: <none>
new: method groovy.lang.MetaClass groovy.lang.GroovyObject::getMetaClass() @ foo.Foo

SOURCE: BREAKING, BINARY: BREAKING

From old archive: <none>
From new archive: ignores-magic-methods-added-by-groovy-when-comparing-the-same-groovy-class.jar
```

## After this PR
==COMMIT_MSG==
`gradle-revapi` will not spuriously identify the addition of abstract methods from `groovy.lang.GroovyObject` as breaks.
==COMMIT_MSG==

## Possible downsides?
None I can think of, other than possibly not covering all possible cases where groovy does this, but we can add them as they come up.

Fixed #65.

