### PR TITLE
Fix interaction with baseline-circleci

### DIFF
--- a/changelog/@unreleased/pr-79.v2.yml
+++ b/changelog/@unreleased/pr-79.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixes `ConcurrentModificationException` thrown when `com.palantir.baseline`
+    (or more specifically `com.palantir.baseline-circleci`) is applied before `gradle-revapi`.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/79

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -57,12 +57,12 @@ public final class RevapiPlugin implements Plugin<Project> {
             task.getOldGroupNameVersion().set(project.getProviders().provider(extension::oldGroupNameVersion));
         });
 
-        Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
-
-        project.getTasks().withType(RevapiJavaTask.class).forEach(task -> {
+        project.getTasks().withType(RevapiJavaTask.class).configureEach(task -> {
             task.dependsOn(allJarTasksIncludingDependencies(project, revapiNewApi));
             task.configManager().set(configManager);
             task.newApiDependencyJars().set(revapiNewApi);
+
+            Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
             task.newApiJars().set(jarTask.getOutputs().getFiles());
         });
 

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -57,14 +57,12 @@ public final class RevapiPlugin implements Plugin<Project> {
             task.getOldGroupNameVersion().set(project.getProviders().provider(extension::oldGroupNameVersion));
         });
 
+        Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
+
         project.getTasks().withType(RevapiJavaTask.class).forEach(task -> {
             task.dependsOn(allJarTasksIncludingDependencies(project, revapiNewApi));
-
             task.configManager().set(configManager);
-
             task.newApiDependencyJars().set(revapiNewApi);
-
-            Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
             task.newApiJars().set(jarTask.getOutputs().getFiles());
         });
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -395,6 +395,10 @@ class RevapiSpec extends IntegrationSpec {
 
     def 'does not throw exception when baseline-circleci is applied before this plugin'() {
         when:
+        addSubproject 'subproject',  """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+        """
+
         buildFile << """
             buildscript {
                 repositories {
@@ -411,7 +415,6 @@ class RevapiSpec extends IntegrationSpec {
             // baseline-circleci is the bad plugin, but might as well test against all of baseline
             apply plugin: 'com.palantir.baseline'
             apply plugin: 'com.palantir.baseline-circleci'
-            apply plugin: '${TestConstants.PLUGIN_NAME}'
         """
 
         then:

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -393,6 +393,31 @@ class RevapiSpec extends IntegrationSpec {
         assert stderr.contains('method void foo.Foo::setSomeProperty(java.lang.String)')
     }
 
+    def 'does not throw exception when baseline-circleci is applied before this plugin'() {
+        when:
+        buildFile << """
+            buildscript {
+                repositories {
+                    maven { url "https://palantir.bintray.com/releases" }
+                    jcenter()
+                    gradlePluginPortal()
+                }
+            
+                dependencies {
+                    classpath 'com.palantir.baseline:gradle-baseline-java:2.21.0'
+                }
+            }
+
+            // baseline-circleci is the bad plugin, but might as well test against all of baseline
+            apply plugin: 'com.palantir.baseline'
+            apply plugin: 'com.palantir.baseline-circleci'
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+        """
+
+        then:
+        runTasksSuccessfully("tasks")
+    }
+
     private String testMavenPublication() {
         return """
             publishing {


### PR DESCRIPTION
## Before this PR
Due to some unknown interaction with `baseline-circleci`, a `ConcurrentModificationException` is thrown. See #70.

## After this PR
==COMMIT_MSG==
Fixes `ConcurrentModificationException` thrown when `com.palantir.baseline` (or more specifically `com.palantir.baseline-circleci`) is applied before `gradle-revapi`.
==COMMIT_MSG==

## Possible downsides?
I don't why this interaction is actually causing it to fail in the first place.

Fixes #70 