### PR TITLE
Fix test reports bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 buildscript {
     repositories {
         jcenter()
@@ -61,6 +63,12 @@ dependencies {
 
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value::annotations"
+}
+
+test {
+    environment = System.getenv().entrySet().stream()
+            .filter { entry -> entry.key != 'CIRCLE_TEST_REPORTS' }
+            .collect(Collectors.toMap({ it.key }, { it.value }))
 }
 
 gradlePlugin {

--- a/changelog/@unreleased/pr-82.v2.yml
+++ b/changelog/@unreleased/pr-82.v2.yml
@@ -1,6 +1,0 @@
-type: fix
-fix:
-  description: The `CIRCLE_TEST_REPORTS` environment variable will no longer be used
-    to discover what directory to place the junit xml report into.
-  links:
-  - https://github.com/palantir/gradle-revapi/pull/82

--- a/src/main/java/com/palantir/gradle/revapi/RevapiReportTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiReportTask.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 import org.gradle.api.tasks.TaskAction;
 
 public class RevapiReportTask extends RevapiJavaTask {
@@ -84,6 +85,10 @@ public class RevapiReportTask extends RevapiJavaTask {
     }
 
     private File junitOutput() {
-        return new File(getProject().getBuildDir(), "junit-reports/revapi/revapi-" + getProject().getName() + ".xml");
+        Optional<String> circleReportsDir = Optional.ofNullable(System.getenv("CIRCLE_TEST_REPORTS"));
+        File reportsDir = circleReportsDir
+                .map(File::new)
+                .orElseGet(() -> getProject().getBuildDir());
+        return new File(reportsDir, "junit-reports/revapi/revapi-" + getProject().getName() + ".xml");
     }
 }


### PR DESCRIPTION
## Before this PR
The circle template sets CIRCLE_TEST_REPORTS that we were also using in the actual plugin to determine where to put our junit xmls. This broke our tests, as it would put the junit xml in an unexpected place.

Reverts #82

## After this PR
We setup the gradle test task to strip out the `CIRCLE_TEST_REPORTS` env var. 

## Possible downsides?
Bringing more custom gradle into this world.

