### PR TITLE
Fix "resource revapi-old-api-failed-to-resolve.txt not found" error

### DIFF
--- a/changelog/@unreleased/pr-119.v2.yml
+++ b/changelog/@unreleased/pr-119.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixes errors of the form `resource revapi-old-api-failed-to-resolve.txt
+    not found` when previous API version have failed to resolve.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/119

--- a/src/main/java/com/palantir/gradle/revapi/ExceptionMessages.java
+++ b/src/main/java/com/palantir/gradle/revapi/ExceptionMessages.java
@@ -18,19 +18,26 @@ package com.palantir.gradle.revapi;
 
 import com.google.common.io.Resources;
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
 
 final class ExceptionMessages {
+    private static final String OLD_API_FAILED_TO_RESOLVE = "revapi-old-api-failed-to-resolve.txt";
+
     private ExceptionMessages() { }
 
     public static String failedToResolve(Project project, String errors) {
         try {
-            String errorTemplate = Resources.toString(
-                    Resources.getResource("revapi-old-api-failed-to-resolve.txt"),
-                    StandardCharsets.UTF_8);
+            URL errorMessageTemplateUrl = Optional.ofNullable(
+                            ExceptionMessages.class.getClassLoader().getResource(OLD_API_FAILED_TO_RESOLVE))
+                    .orElseThrow(() -> new RuntimeException(
+                            "Could not find template for error message for " + OLD_API_FAILED_TO_RESOLVE));
+
+            String errorTemplate = Resources.toString(errorMessageTemplateUrl, StandardCharsets.UTF_8);
 
             return errorTemplate
                     .replace("{{versionOverrideTaskName}}", RevapiPlugin.VERSION_OVERRIDE_TASK_NAME)


### PR DESCRIPTION
## Before this PR
On some projects, when you run `./gradlew revapi` it fails with this error:

```
Could not determine the dependencies of task ':project:revapiAnalyze'.
> resource revapi-old-api-failed-to-resolve.txt not found.
```

Upon investigation, I think this is because we use Guava's `Resources.getResource(...)` and have just recently changed the oldApiVersion resolution to happen as an input. `Resources.getResource(...)` uses the context classloader, which is the classloader of the thread that gradle is using to calculate the inputs. This classloader seems to not have the gradle-revapi classpath. The solution is to specify a particular class to look relative to.

## After this PR
==COMMIT_MSG==
Fixes errors of the form `resource revapi-old-api-failed-to-resolve.txt not found` when previous API version have failed to resolve.
==COMMIT_MSG==