### PR TITLE
Dont run if no versions available, include initial 0.0.0 version

### DIFF
--- a/changelog/@unreleased/pr-120.v2.yml
+++ b/changelog/@unreleased/pr-120.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: For projects with no tags, or just a single `0.0.0` tag on the initial
+    commit, `gradle-revapi` will not run.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/120

--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -33,7 +33,8 @@ final class GitVersionUtils {
     private GitVersionUtils() { }
 
     public static Stream<String> previousGitTags(Project project) {
-        return StreamSupport.stream(new PreviousGitTags(project), false);
+        return StreamSupport.stream(new PreviousGitTags(project), false)
+                .filter(tag -> !isInitial000Tag(project, tag));
     }
 
     private static Optional<String> previousGitTagFromRef(Project project, String ref) {
@@ -53,6 +54,16 @@ final class GitVersionUtils {
         }
 
         return Optional.of(describeResult.stdoutOrThrowIfNonZero());
+    }
+
+    private static boolean isInitial000Tag(Project project, String tag) {
+        if (!tag.equals("0.0.0")) {
+            return false;
+        }
+
+        GitResult foo = execute(project, "git", "rev-parse", "--verify", "--quiet", "0.0.0^");
+        boolean parentDoesNotExist = foo.exitCode() != 0;
+        return parentDoesNotExist;
     }
 
     private static GitResult execute(Project project, String... command) {

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -71,10 +71,10 @@ public final class RevapiPlugin implements Plugin<Project> {
                     task.getNewApiDependencyJars().set(revapiNewApi);
                     task.getOldApiJars().set(
                             maybeOldApi.map(oldApi ->
-                                    oldApi.map(OldApi::jars).orElse(Collections.emptySet())));
+                                    oldApi.map(OldApi::jars).orElseGet(Collections::emptySet)));
                     task.getOldApiDependencyJars().set(
                             maybeOldApi.map(oldApi ->
-                                    oldApi.map(OldApi::dependencyJars).orElse(Collections.emptySet())));
+                                    oldApi.map(OldApi::dependencyJars).orElseGet(Collections::emptySet)));
 
                     task.getAnalysisResultsFile().set(new File(project.getBuildDir(), "revapi/revapi-results.json"));
 

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -21,16 +21,19 @@ import com.palantir.gradle.revapi.ResolveOldApi.OldApi;
 import com.palantir.gradle.revapi.config.AcceptedBreak;
 import com.palantir.gradle.revapi.config.GroupAndName;
 import java.io.File;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentResult;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -49,13 +52,16 @@ public final class RevapiPlugin implements Plugin<Project> {
 
         ConfigManager configManager = new ConfigManager(configFile(project));
 
+        Provider<Optional<OldApi>> maybeOldApi =
+                ResolveOldApi.oldApiProvider(project, extension, configManager);
+        Spec<Task> oldApiIsPresent = _task -> maybeOldApi.get().isPresent();
+
         TaskProvider<RevapiAnalyzeTask> analyzeTask = project.getTasks()
                 .register("revapiAnalyze", RevapiAnalyzeTask.class, task -> {
                     Configuration revapiNewApi = project.getConfigurations().create("revapiNewApi", conf -> {
                         conf.extendsFrom(
                                 project.getConfigurations().getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME));
                     });
-                    Provider<OldApi> oldApi = ResolveOldApi.oldApiProvider(project, extension, configManager);
 
                     task.dependsOn(allJarTasksIncludingDependencies(project, revapiNewApi));
                     task.getAcceptedBreaks().set(acceptedBreaks(project, configManager, extension.oldGroupAndName()));
@@ -63,10 +69,14 @@ public final class RevapiPlugin implements Plugin<Project> {
                     Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
                     task.getNewApiJars().set(jarTask.getOutputs().getFiles());
                     task.getNewApiDependencyJars().set(revapiNewApi);
-                    task.getOldApiJars().set(oldApi.map(OldApi::jars));
-                    task.getOldApiDependencyJars().set(oldApi.map(OldApi::dependencyJars));
+                    task.getOldApiJars()
+                            .set(maybeOldApi.map(oldApi1 -> oldApi1.map(OldApi::jars).orElse(Collections.emptySet())));
+                    task.getOldApiDependencyJars().set(maybeOldApi.map(
+                            oldApi1 -> oldApi1.map(OldApi::dependencyJars).orElse(Collections.emptySet())));
 
                     task.getAnalysisResultsFile().set(new File(project.getBuildDir(), "revapi/revapi-results.json"));
+
+                    task.onlyIf(oldApiIsPresent);
                 });
 
         TaskProvider<RevapiReportTask> reportTask = project.getTasks()
@@ -74,6 +84,8 @@ public final class RevapiPlugin implements Plugin<Project> {
                     task.dependsOn(analyzeTask);
                     task.getAnalysisResultsFile().set(analyzeTask.flatMap(RevapiAnalyzeTask::getAnalysisResultsFile));
                     task.getJunitOutputFile().set(junitOutput(project));
+
+                    task.onlyIf(oldApiIsPresent);
                 });
 
         project.getTasks().findByName(LifecycleBasePlugin.CHECK_TASK_NAME).dependsOn(reportTask);

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -69,10 +69,12 @@ public final class RevapiPlugin implements Plugin<Project> {
                     Jar jarTask = project.getTasks().withType(Jar.class).getByName(JavaPlugin.JAR_TASK_NAME);
                     task.getNewApiJars().set(jarTask.getOutputs().getFiles());
                     task.getNewApiDependencyJars().set(revapiNewApi);
-                    task.getOldApiJars()
-                            .set(maybeOldApi.map(oldApi1 -> oldApi1.map(OldApi::jars).orElse(Collections.emptySet())));
-                    task.getOldApiDependencyJars().set(maybeOldApi.map(
-                            oldApi1 -> oldApi1.map(OldApi::dependencyJars).orElse(Collections.emptySet())));
+                    task.getOldApiJars().set(
+                            maybeOldApi.map(oldApi ->
+                                    oldApi.map(OldApi::jars).orElse(Collections.emptySet())));
+                    task.getOldApiDependencyJars().set(
+                            maybeOldApi.map(oldApi ->
+                                    oldApi.map(OldApi::dependencyJars).orElse(Collections.emptySet())));
 
                     task.getAnalysisResultsFile().set(new File(project.getBuildDir(), "revapi/revapi-results.json"));
 

--- a/src/test/groovy/com/palantir/gradle/revapi/GitVersionUtilsSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/GitVersionUtilsSpec.groovy
@@ -81,6 +81,27 @@ class GitVersionUtilsSpec extends AbstractProjectSpec {
         assert previousGitTags() == ["3", "2", "1"]
     }
 
+    def 'when the initial commit is 0.0.0, ignore it as its the first, unpublished release'() {
+        when:
+        git.command 'git commit --allow-empty -m "Initial"'
+        git.command 'git tag 0.0.0'
+        git.command 'git commit --allow-empty -m "Another"'
+
+        then:
+        assert previousGitTags().isEmpty()
+    }
+
+    def 'when a non-initial commit is 0.0.0, return it'() {
+        when:
+        git.command 'git commit --allow-empty -m "Initial"'
+        git.command 'git commit --allow-empty -m "AnotherInitial"'
+        git.command 'git tag 0.0.0'
+        git.command 'git commit --allow-empty -m "Additional"'
+
+        then:
+        assert previousGitTags() == ['0.0.0']
+    }
+
     private List<String> previousGitTags() {
         GitVersionUtils.previousGitTags(getProject()).collect(Collectors.toList())
     }

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -186,6 +186,29 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingResolutionFailure()
     }
 
+    def 'skips revapi tasks when the versiosn to check is empty list'() {
+        when:
+        buildFile << """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+            apply plugin: 'java'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            revapi {
+                oldGroup = 'org.revapi'
+                oldName = 'revapi'
+                oldVersions = []
+            }
+        """.stripIndent()
+
+        then:
+        def executionResult = runTasksSuccessfully('revapi')
+        executionResult.wasSkipped(':revapiAnalyze')
+        executionResult.wasSkipped(':revapi')
+    }
+
     def 'when the previous git tag has failed to publish, it will look back up to a further git tag'() {
         when:
         git.initWithTestUser()

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -186,7 +186,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingResolutionFailure()
     }
 
-    def 'skips revapi tasks when the versiosn to check is empty list'() {
+    def 'skips revapi tasks when the versions to check is empty list'() {
         when:
         buildFile << """
             apply plugin: '${TestConstants.PLUGIN_NAME}'


### PR DESCRIPTION
## Before this PR
If you run `gradle-revapi` on a blank, newly made repo with no tags, it will fail and not allow you to do anything, as it cannot find any versions to compare about. Similarly when a project has been created by our internal project creation helper, which tags the initial commit as `0.0.0`, but it's never released.

## After this PR
==COMMIT_MSG==
For projects with no tags, or just a single `0.0.0` tag on the initial commit, `gradle-revapi` will not run.
==COMMIT_MSG==

## Possible downsides?
Someone actually wants to run revapi against an initial `0.0.0`, but this seems extremely unlikely.