### PR TITLE
Strip v prefix from git tags

### DIFF
--- a/changelog/@unreleased/pr-146.v2.yml
+++ b/changelog/@unreleased/pr-146.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: When looking for the last published version in git tags, `v` prefixes
+    will be stripped.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/146

--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -34,7 +34,8 @@ final class GitVersionUtils {
 
     public static Stream<String> previousGitTags(Project project) {
         return StreamSupport.stream(new PreviousGitTags(project), false)
-                .filter(tag -> !isInitial000Tag(project, tag));
+                .filter(tag -> !isInitial000Tag(project, tag))
+                .map(GitVersionUtils::stripVFromTag);
     }
 
     private static Optional<String> previousGitTagFromRef(Project project, String ref) {
@@ -64,6 +65,14 @@ final class GitVersionUtils {
         GitResult foo = execute(project, "git", "rev-parse", "--verify", "--quiet", "0.0.0^");
         boolean parentDoesNotExist = foo.exitCode() != 0;
         return parentDoesNotExist;
+    }
+
+    private static String stripVFromTag(String tag) {
+        if (tag.startsWith("v")) {
+            return tag.substring(1);
+        } else {
+            return tag;
+        }
     }
 
     private static GitResult execute(Project project, String... command) {

--- a/src/test/groovy/com/palantir/gradle/revapi/GitVersionUtilsSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/GitVersionUtilsSpec.groovy
@@ -102,6 +102,16 @@ class GitVersionUtilsSpec extends AbstractProjectSpec {
         assert previousGitTags() == ['0.0.0']
     }
 
+    def 'strips tags of v prefixes'() {
+        when:
+        git.command 'git commit --allow-empty -m "Initial"'
+        git.command 'git tag v1.2.3'
+        git.command 'git commit --allow-empty -m "Additional"'
+
+        then:
+        assert previousGitTags() == ['1.2.3']
+    }
+
     private List<String> previousGitTags() {
         GitVersionUtils.previousGitTags(getProject()).collect(Collectors.toList())
     }


### PR DESCRIPTION
## Before this PR
See #145. Externally, some people are using this project on repos that `v`-prefix git tags, which doesn't match up with the maven coordinate version.

## After this PR
==COMMIT_MSG==
When looking for the last published version in git tags, `v` prefixes will be stripped.
==COMMIT_MSG==

## Possible downsides?
If someone has actually published this maven artifact with a `v` prefixed version, it will now break.

Closes #145.
