### PR TITLE
Sort GradleRevapiConfig values

### DIFF
--- a/changelog/@unreleased/pr-194.v2.yml
+++ b/changelog/@unreleased/pr-194.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`revapi.yml` entires are now sorted to ensure that new entries do
+    not cause existing entires to be reordered.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/194

--- a/src/main/java/com/palantir/gradle/revapi/config/AcceptedBreak.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/AcceptedBreak.java
@@ -18,6 +18,8 @@ package com.palantir.gradle.revapi.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.Comparators;
+import java.util.Comparator;
 import java.util.Optional;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
@@ -25,7 +27,8 @@ import org.immutables.value.Value;
 @Value.Immutable
 @Serial.Structural
 @JsonDeserialize(as = ImmutableAcceptedBreak.class)
-public interface AcceptedBreak {
+public interface AcceptedBreak extends Comparable<AcceptedBreak> {
+    @JsonProperty("code")
     String code();
 
     @JsonProperty("old")
@@ -34,7 +37,20 @@ public interface AcceptedBreak {
     @JsonProperty("new")
     Optional<String> newElement();
 
+    @JsonProperty("justification")
     Justification justification();
+
+    @Value.Lazy
+    default Comparator<AcceptedBreak> comparator() {
+        return Comparator.comparing(AcceptedBreak::code)
+                .thenComparing(AcceptedBreak::oldElement, Comparators.emptiesFirst(Comparator.<String>naturalOrder()))
+                .thenComparing(AcceptedBreak::newElement, Comparators.emptiesFirst(Comparator.<String>naturalOrder()));
+    }
+
+    @Override
+    default int compareTo(AcceptedBreak other) {
+        return comparator().compare(this, other);
+    }
 
     class Builder extends ImmutableAcceptedBreak.Builder {
         public Builder justification(String justification) {

--- a/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
@@ -27,14 +27,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutableGradleRevapiConfig.class)
 public abstract class GradleRevapiConfig {
-    protected abstract Map<GroupNameVersion, String> versionOverrides();
-    protected abstract Map<Version, PerProjectAcceptedBreaks> acceptedBreaks();
+    @Value.NaturalOrder
+    protected abstract SortedMap<GroupNameVersion, String> versionOverrides();
+    @Value.NaturalOrder
+    protected abstract SortedMap<Version, PerProjectAcceptedBreaks> acceptedBreaks();
 
     public final Optional<Version> versionOverrideFor(GroupNameVersion groupNameVersion) {
         return Optional.ofNullable(versionOverrides().get(groupNameVersion))

--- a/src/main/java/com/palantir/gradle/revapi/config/GroupAndName.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GroupAndName.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface GroupAndName {
+public interface GroupAndName extends Comparable<GroupAndName> {
     String group();
     String name();
 
@@ -44,6 +44,11 @@ public interface GroupAndName {
                 .group(split.get(0))
                 .name(split.get(1))
                 .build();
+    }
+
+    @Override
+    default int compareTo(GroupAndName other) {
+        return this.asString().compareTo(other.asString());
     }
 
     default GroupNameVersion withVersion(Version version) {

--- a/src/main/java/com/palantir/gradle/revapi/config/GroupNameVersion.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GroupNameVersion.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface GroupNameVersion {
+public interface GroupNameVersion extends Comparable<GroupNameVersion> {
     GroupAndName groupAndName();
     Version version();
 
@@ -47,6 +47,11 @@ public interface GroupNameVersion {
                         .build())
                 .version(Version.fromString(split.get(2)))
                 .build();
+    }
+
+    @Override
+    default int compareTo(GroupNameVersion other) {
+        return this.asString().compareTo(other.asString());
     }
 
     class Builder extends ImmutableGroupNameVersion.Builder { }

--- a/src/main/java/com/palantir/gradle/revapi/config/PerProjectAcceptedBreaks.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/PerProjectAcceptedBreaks.java
@@ -18,29 +18,31 @@ package com.palantir.gradle.revapi.config;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @JsonDeserialize(as = ImmutablePerProjectAcceptedBreaks.class)
 abstract class PerProjectAcceptedBreaks {
     @JsonValue
-    protected abstract Map<GroupAndName, Set<AcceptedBreak>> acceptedBreaks();
+    @Value.NaturalOrder
+    protected abstract SortedMap<GroupAndName, SortedSet<AcceptedBreak>> acceptedBreaks();
 
     public Set<AcceptedBreak> acceptedBreaksFor(GroupAndName groupAndName) {
-        return acceptedBreaks().getOrDefault(groupAndName, Collections.emptySet());
+        return acceptedBreaks().getOrDefault(groupAndName, Collections.emptySortedSet());
     }
 
     public PerProjectAcceptedBreaks merge(GroupAndName groupAndName, Set<AcceptedBreak> acceptedBreaks) {
-        Map<GroupAndName, Set<AcceptedBreak>> newAcceptedBreaks = new HashMap<>(acceptedBreaks());
-        newAcceptedBreaks.put(groupAndName, Sets.union(
-                acceptedBreaks,
-                this.acceptedBreaks().getOrDefault(groupAndName, ImmutableSet.of())));
+        SortedMap<GroupAndName, SortedSet<AcceptedBreak>> newAcceptedBreaks = new TreeMap<>(acceptedBreaks());
+        newAcceptedBreaks.put(groupAndName, ImmutableSortedSet.<AcceptedBreak>naturalOrder()
+                .addAll(acceptedBreaks().getOrDefault(groupAndName, ImmutableSortedSet.of()))
+                .addAll(acceptedBreaks)
+                .build());
 
         return builder()
                 .putAllAcceptedBreaks(newAcceptedBreaks)

--- a/src/main/java/com/palantir/gradle/revapi/config/Version.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/Version.java
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface Version {
+public interface Version extends Comparable<Version> {
+
     @JsonValue
     String asString();
 
@@ -30,6 +31,11 @@ public interface Version {
         return builder()
                 .asString(version)
                 .build();
+    }
+
+    @Override
+    default int compareTo(Version other) {
+        return this.asString().compareTo(other.asString());
     }
 
     class Builder extends ImmutableVersion.Builder { }


### PR DESCRIPTION
Fixes #115

## Before this PR
Map entires in `GradleRevapiConfig` are not sorted. This results in non-deterministic serialization of these values. A consequence of this is that revapi changes not only add new entires, they may also reorder existing entries. This makes it difficult to review those changes and clearly see which entires were added to `revpai.yml`.

## After this PR
Map entires in `GradleRevapiConfig` are now sorted. When `revpai.yml` needs to be updated, existing entires will no longer be spuriously reordered.