### PR TITLE
Moving from imlementation to compileOnly is not a break

### DIFF
--- a/changelog/@unreleased/pr-219.v2.yml
+++ b/changelog/@unreleased/pr-219.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Revapi properly handles moving dependencies to `compileOnly` without
+    claiming a break has occurred.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/219

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -59,7 +59,7 @@ public final class RevapiPlugin implements Plugin<Project> {
                 .register("revapiAnalyze", RevapiAnalyzeTask.class, task -> {
                     Configuration revapiNewApi = project.getConfigurations().create("revapiNewApi", conf -> {
                         conf.extendsFrom(
-                                project.getConfigurations().getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME));
+                                project.getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
                     });
 
                     task.dependsOn(allJarTasksIncludingDependencies(project, revapiNewApi));


### PR DESCRIPTION
## Before this PR
If you list a dependency as `implementation`, then move to `compileOnly`, revapi will tell you your code is broken. We were resolving `runtimeElements` (now we are resolving `compileClasspath`) - this image may help understand:

![java-library-ignore-deprecated-main](https://user-images.githubusercontent.com/397795/76332418-405d1c00-62e8-11ea-970e-d73c5dcf3d3b.png)

From here: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph

## After this PR
==COMMIT_MSG==
Revapi properly handles moving dependencies to `compileOnly` without claiming a break has occurred.
==COMMIT_MSG==

