### PR TITLE
Fix moving class between projects

### DIFF
--- a/changelog/@unreleased/pr-221.v2.yml
+++ b/changelog/@unreleased/pr-221.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Moving a java class from a project to a dependency of that project
+    is allowed, so long as the dependent project is at the `api` level.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/221

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
@@ -21,7 +21,10 @@ import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.CompileClasspath;
@@ -46,12 +49,14 @@ public class RevapiAnalyzeTask extends DefaultTask {
 
     private final SetProperty<AcceptedBreak> acceptedBreaks =
             getProject().getObjects().setProperty(AcceptedBreak.class);
-    private final SetProperty<File> newApiJars = getProject().getObjects().setProperty(File.class);
-    private final SetProperty<File> newApiDependencyJars =
-            getProject().getObjects().setProperty(File.class);
-    private final SetProperty<File> oldApiJars = getProject().getObjects().setProperty(File.class);
-    private final SetProperty<File> oldApiDependencyJars =
-            getProject().getObjects().setProperty(File.class);
+    private final Property<FileCollection> newApiJars =
+            getProject().getObjects().property(FileCollection.class);
+    private final Property<FileCollection> newApiDependencyJars =
+            getProject().getObjects().property(FileCollection.class);
+    private final Property<FileCollection> oldApiJars =
+            getProject().getObjects().property(FileCollection.class);
+    private final Property<FileCollection> oldApiDependencyJars =
+            getProject().getObjects().property(FileCollection.class);
     private final RegularFileProperty analysisResultsFile =
             getProject().getObjects().fileProperty();
 
@@ -61,22 +66,22 @@ public class RevapiAnalyzeTask extends DefaultTask {
     }
 
     @CompileClasspath
-    public final SetProperty<File> getNewApiJars() {
+    public final Property<FileCollection> getNewApiJars() {
         return newApiJars;
     }
 
     @CompileClasspath
-    public final SetProperty<File> getNewApiDependencyJars() {
+    public final Property<FileCollection> getNewApiDependencyJars() {
         return newApiDependencyJars;
     }
 
     @CompileClasspath
-    public final SetProperty<File> getOldApiJars() {
+    public final Property<FileCollection> getOldApiJars() {
         return oldApiJars;
     }
 
     @CompileClasspath
-    public final SetProperty<File> getOldApiDependencyJars() {
+    public final Property<FileCollection> getOldApiDependencyJars() {
         return oldApiDependencyJars;
     }
 
@@ -126,16 +131,15 @@ public class RevapiAnalyzeTask extends DefaultTask {
         return RevapiConfig.empty().withIgnoredBreaks(acceptedBreaks.get());
     }
 
-    private API api(SetProperty<File> apiJars, SetProperty<File> dependencyJars) {
+    private API api(Provider<FileCollection> apiJars, Provider<FileCollection> dependencyJars) {
         return API.builder()
                 .addArchives(toFileArchives(apiJars))
                 .addSupportArchives(toFileArchives(dependencyJars))
                 .build();
     }
 
-    private static List<FileArchive> toFileArchives(SetProperty<File> property) {
-        return property.get().stream()
-                .filter(File::isFile)
+    private static List<FileArchive> toFileArchives(Provider<FileCollection> property) {
+        return property.get().filter(File::isFile).getFiles().stream()
                 .map(FileArchive::new)
                 .collect(Collectors.toList());
     }

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -417,7 +417,7 @@ class RevapiSpec extends IntegrationSpec {
 
     }
 
-    def 'moving a class from one project to a dependent project is not a break'() {
+    def 'moving a class from one project to a dependent project is not a break (only if it is in the api configuration)'() {
         buildFile << """
             allprojects {
                 apply plugin: 'java-library'
@@ -456,8 +456,15 @@ class RevapiSpec extends IntegrationSpec {
         writeToFile two, 'src/main/java/foo/Foo.java', originalJavaFile.text
         originalJavaFile.delete()
 
+        and:
+        println runTasksSuccessfully("revapi").standardOutput
+
+        and:
+        def oneBuildGradle = new File(one, 'build.gradle')
+        oneBuildGradle.text = oneBuildGradle.text.replace('api project', 'implementation project')
+
         then:
-        runTasksSuccessfully("revapi")
+        assert runRevapiExpectingFailure().contains('java.class.removed')
     }
 
     def 'ignores scala classes'() {

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -19,6 +19,7 @@ package com.palantir.gradle.revapi
 
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
+import spock.util.environment.RestoreSystemProperties
 
 class RevapiSpec extends IntegrationSpec {
     private Git git
@@ -671,6 +672,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully('revapi').wasExecuted('revapiAnalyze')
     }
 
+    @RestoreSystemProperties
     def 'breaks detected in conjure projects should be limited to those which break java but are not caught by conjure-backcompat'() {
         when:
         rootProjectNameIs('api')
@@ -749,6 +751,16 @@ class RevapiSpec extends IntegrationSpec {
         """.stripIndent()
 
         and:
+        /*
+        Ignore warnings because:
+
+        java.lang.IllegalArgumentException: Mutable Project State warnings were found (Set the ignoreMutableProjectStateWarnings system property during the test to ignore):
+ - The configuration :api-objects:compileClasspath was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project.  See https://docs.gradle.org/5.6.4/userguide/troubleshooting_dependency_resolution.html#sub:configuration_resolution_constraints for more details. This behaviour has been deprecated and is scheduled to be removed in Gradle 6.0.
+ - The configuration :api-jersey:compileClasspath was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project.  See https://docs.gradle.org/5.6.4/userguide/troubleshooting_dependency_resolution.html#sub:configuration_resolution_constraints for more details. This behaviour has been deprecated and is scheduled to be removed in Gradle 6.0.
+ - The configuration :api-retrofit:compileClasspath was resolved without accessing the project in a safe manner.  This may happen when a configuration is resolved from a thread not managed by Gradle or from a different project.  See https://docs.gradle.org/5.6.4/userguide/troubleshooting_dependency_resolution.html#sub:configuration_resolution_constraints for more details. This behaviour has been deprecated and is scheduled to be removed in Gradle 6.0.
+        */
+        System.setProperty('ignoreMutableProjectStateWarnings', 'true')
+        System.setProperty('ignoreDeprecations', 'true')
         runTasksSuccessfully('compileConjure', 'publish')
 
         and:
@@ -862,5 +874,25 @@ class RevapiSpec extends IntegrationSpec {
         File junitOutput = new File(projectDir, "build/junit-reports/revapi/revapi-${projectName}.xml")
         new XmlParser().parse(junitOutput)
         assert junitOutput.text.contains("java.class.removed")
+    }
+
+    @Override
+    ExecutionResult runTasksSuccessfully(String... tasks) {
+        ExecutionResult result = runTasks(tasks)
+        if (result.failure) {
+            println result.standardOutput
+            result.rethrowFailure()
+        }
+        result
+    }
+
+    @Override
+    ExecutionResult runTasksWithFailure(String... tasks) {
+        ExecutionResult result = runTasks(tasks)
+        if (result.success) {
+            println result.standardOutput
+            assert false
+        }
+        result
     }
 }


### PR DESCRIPTION
Fixes #60.

## Before this PR
If you move a public java class between one project and `api` project dependency, revapi will tell you the class has been removed. This is incorrect, assuming you are using a dependency resolver, as you will pull in the other jar and have access to it's types.

## After this PR
==COMMIT_MSG==
Moving a java class from a project to a dependency of that project is allowed, so long as the dependent project is at the `api` level.
==COMMIT_MSG==

We essentially include project dependency jars at `api` level in our revapi analysis.

## Possible downsides?
Since we are inspecting a larger API surface (before: just your project's jar, after: your project's jar and all jars depended on by your project in the repo), there's a higher risk of OOMing.

