### PR TITLE
If no versions of library have been published, skip analysis

### DIFF
--- a/changelog/@unreleased/pr-223.v2.yml
+++ b/changelog/@unreleased/pr-223.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: If there are no published versions of the library to check against,
+    the analysis tasks will be skipped. This allows you to apply the revapi plugin
+    to new Gradle projects.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/223

--- a/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
+++ b/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.revapi;
 import com.google.common.collect.Sets;
 import com.palantir.gradle.revapi.OldApiConfigurations.CouldNotResolveOldApiException;
 import com.palantir.gradle.revapi.config.GradleRevapiConfig;
+import com.palantir.gradle.revapi.config.GroupAndName;
 import com.palantir.gradle.revapi.config.GroupNameVersion;
 import com.palantir.gradle.revapi.config.Version;
 import java.io.File;
@@ -57,10 +58,12 @@ final class ResolveOldApi {
             return Optional.empty();
         }
 
+        GroupAndName oldGroupAndName = extension.oldGroupAndName().get();
+
         Map<Version, CouldNotResolveOldApiException> exceptionsPerVersion = new LinkedHashMap<>();
         for (String oldVersionString : oldVersionStrings) {
             GroupNameVersion oldGroupNameVersion = possiblyReplacedOldVersionFor(
-                    config, extension.oldGroupAndName().get().withVersion(Version.fromString(oldVersionString)));
+                    config, oldGroupAndName.withVersion(Version.fromString(oldVersionString)));
 
             try {
                 OldApi oldApi = resolveOldApiWithVersion(project, oldGroupNameVersion);
@@ -78,6 +81,14 @@ final class ResolveOldApi {
             } catch (CouldNotResolveOldApiException e) {
                 exceptionsPerVersion.put(oldGroupNameVersion.version(), e);
             }
+        }
+
+        try {
+            OldApiConfigurations.resolveOldConfiguration(
+                    project, oldGroupAndName.withVersion(Version.fromString("+")), false);
+        } catch (CouldNotResolveOldApiException e) {
+            // Since there are no published versions *at all*, skip running revapi
+            return Optional.empty();
         }
 
         throw new IllegalStateException(

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -331,7 +331,9 @@ class RevapiSpec extends IntegrationSpec {
         writeHelloWorld()
 
         then:
-        runTasksSuccessfully('revapi')
+        def executionResult = runTasksSuccessfully('revapi')
+        executionResult.wasSkipped(':revapiAnalyze')
+        executionResult.wasSkipped(':revapi')
     }
 
     def 'handles the output of extra source sets being added to compile configuration'() {

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -311,6 +311,29 @@ class RevapiSpec extends IntegrationSpec {
         assert standardError.contains('willBeRemoved')
     }
 
+    def 'if there are no published versions of the library at all, dont error out'() {
+        when:
+        buildFile << """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+            apply plugin: 'java-library'
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            revapi {
+                oldGroup = 'does.not'
+                oldName = 'exist'
+                oldVersion = '1.0.0'
+            }
+        """.stripIndent()
+
+        writeHelloWorld()
+
+        then:
+        runTasksSuccessfully('revapi')
+    }
+
     def 'handles the output of extra source sets being added to compile configuration'() {
         when:
         buildFile << """


### PR DESCRIPTION
Fixes #110.

## Before this PR
If you create a new project, and apply `gradle-revapi` to it, it will fail because there are no published artifacts to test against.

## After this PR
==COMMIT_MSG==
If there are no published versions of the library to check against, the analysis tasks will be skipped. This allows you to apply the revapi plugin to new Gradle projects.
==COMMIT_MSG==

## Possible downsides?
None I can think of.
