### PR TITLE
Don't add empty accepted breaks in revapiAcceptAllBreaks

### DIFF
--- a/changelog/@unreleased/pr-224.v2.yml
+++ b/changelog/@unreleased/pr-224.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`revapiAcceptAllBreaks` no longer writes accepted break entries for
+    subprojects without breaks.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/224

--- a/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/GradleRevapiConfig.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.revapi.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -96,6 +97,9 @@ public abstract class GradleRevapiConfig {
     }
 
     private static ObjectMapper configureObjectMapper(ObjectMapper objectMapper) {
-        return objectMapper.registerModule(new GuavaModule()).registerModule(new Jdk8Module());
+        return objectMapper
+                .registerModule(new GuavaModule())
+                .registerModule(new Jdk8Module())
+                .setSerializationInclusion(Include.NON_EMPTY);
     }
 }

--- a/src/main/java/com/palantir/gradle/revapi/config/PerProjectAcceptedBreaks.java
+++ b/src/main/java/com/palantir/gradle/revapi/config/PerProjectAcceptedBreaks.java
@@ -38,6 +38,10 @@ abstract class PerProjectAcceptedBreaks {
     }
 
     public PerProjectAcceptedBreaks merge(GroupAndName groupAndName, Set<AcceptedBreak> acceptedBreaks) {
+        if (acceptedBreaks.isEmpty()) {
+            return this;
+        }
+
         SortedMap<GroupAndName, SortedSet<AcceptedBreak>> newAcceptedBreaks = new TreeMap<>(acceptedBreaks());
         newAcceptedBreaks.put(
                 groupAndName,


### PR DESCRIPTION
## Before this PR
`revapiAcceptAllBreaks` writes accepted break entries for all subprojects, even those without any breaks. For subprojects without breaks the value is just an empty list.
```
"0.1.2":
  com.palantir.project:subproject1: []
  com.palantir.project:subproject2: []
  com.palantir.project:subproject3:
    - <accepted-break>
  ...
```

## After this PR
`revapiAcceptAllBreaks` only writes accepted break entries for subprojects with breaks.
```
"0.1.2":
  com.palantir.project:subproject3:
    - <accepted-break>
  ...
```