### PR TITLE
Fix reporting breaks in other projects

### DIFF
--- a/changelog/@unreleased/pr-225.v2.yml
+++ b/changelog/@unreleased/pr-225.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: '`gradle-revapi` will not raise errors about breaks from code in dependent
+    Gradle projects.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/225

--- a/changelog/@unreleased/pr-225.v2.yml
+++ b/changelog/@unreleased/pr-225.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: '`gradle-revapi` will not raise errors about breaks from code in dependent
     Gradle projects.'
   links:

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
@@ -53,6 +53,8 @@ public class RevapiAnalyzeTask extends DefaultTask {
             getProject().getObjects().property(FileCollection.class);
     private final Property<FileCollection> newApiDependencyJars =
             getProject().getObjects().property(FileCollection.class);
+    private final Property<FileCollection> jarsToReportBreaks =
+            getProject().getObjects().property(FileCollection.class);
     private final Property<FileCollection> oldApiJars =
             getProject().getObjects().property(FileCollection.class);
     private final Property<FileCollection> oldApiDependencyJars =
@@ -73,6 +75,11 @@ public class RevapiAnalyzeTask extends DefaultTask {
     @CompileClasspath
     public final Property<FileCollection> getNewApiDependencyJars() {
         return newApiDependencyJars;
+    }
+
+    @CompileClasspath
+    public final Property<FileCollection> getJarsToReportBreaks() {
+        return jarsToReportBreaks;
     }
 
     @CompileClasspath
@@ -107,7 +114,7 @@ public class RevapiAnalyzeTask extends DefaultTask {
                 .build();
 
         RevapiConfig revapiConfig = RevapiConfig.mergeAll(
-                RevapiConfig.defaults(oldApi, newApi),
+                RevapiConfig.defaults(jarsToReportBreaks.get()),
                 RevapiConfig.empty()
                         .withTextReporter(
                                 "gradle-revapi-results.ftl",

--- a/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
@@ -33,11 +33,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
+import org.gradle.api.file.FileCollection;
 import org.immutables.value.Value;
-import org.revapi.API;
-import org.revapi.Archive;
 
 @Value.Immutable
 abstract class RevapiConfig {
@@ -82,18 +79,14 @@ abstract class RevapiConfig {
         return new Builder().from(this).addAllConfig(other.config()).build();
     }
 
-    public static RevapiConfig defaults(API oldApi, API newApi) {
+    public static RevapiConfig defaults(FileCollection jarsToReportBreaks) {
         try {
             String template =
                     Resources.toString(Resources.getResource("revapi-configuration.json"), StandardCharsets.UTF_8);
 
             return fromString(template.replace(
                     "{{ARCHIVE_INCLUDE_REGEXES}}",
-                    Stream.of(newApi, oldApi)
-                            .flatMap(api ->
-                                    StreamSupport.stream(api.getArchives().spliterator(), false))
-                            .map(Archive::getName)
-                            .collect(Collectors.joining("\", \""))));
+                    jarsToReportBreaks.getFiles().stream().map(File::getName).collect(Collectors.joining("\", \""))));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -95,6 +95,9 @@ public final class RevapiPlugin implements Plugin<Project> {
                     task.getNewApiJars().set(thisJarFile.plus(otherProjectsOutputs));
                     task.getNewApiDependencyJars()
                             .set(revapiNewApi.minus(task.getNewApiJars().get()));
+                    task.getJarsToReportBreaks()
+                            .set(project.provider(
+                                    () -> thisJarFile.plus(task.getOldApiJars().get())));
                     task.getOldApiJars()
                             .set(maybeOldApi.map(oldApi ->
                                     oldApi.map(OldApi::jars).map(project::files).orElseGet(project::files)));


### PR DESCRIPTION
## Before this PR
If you had a break in a dependent Gradle project (and that type was used in your project) then `gradle-revapi` would raise an error, even though the code lives in a project you're not checking at the moment.

## After this PR
==COMMIT_MSG==
`gradle-revapi` will not raise errors about breaks from code in dependent Gradle projects.
==COMMIT_MSG==

We force revapi to only report errors from the project jar.
