### PR TITLE
revapiAcceptAllBreaks tolerates unpublished libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,21 @@ error message `gradle-revapi` produces.
 * To accept a single break, run:
   ```
   ./gradlew revapiAcceptBreak --justification "{why this is ok}" \
-          --code "{reavpi check code}" \
+          --code "{revapi check code}" \
           --old "{optional revapi description of old element}" \
           --new "{optional revapi description of new element}"
-  ``` 
-  
+  ```
+
 * To accept all the breaks in a gradle project run:
   ```
   ./gradlew :project:revapiAcceptAllBreaks
   ```
-  
+
 * To accept all the breaks in all gradle projects run:
   ```
   ./gradlew revapiAcceptAllBreaks
   ```
-  
+
 Running any of these tasks will add the breaks to the `.palantir/revapi.yml` file in the format"
 
 ```yml
@@ -97,7 +97,7 @@ acceptedBreaks:
 
 Sometimes the previous release will have a successfully applied a git tag but a failed publish build. In this
 case `gradle-revapi` will fail as it cannot resolve the previous API to compare against. To resolve this, you can
-possible to set a *version override* that will use a different version instead of the last git tag. To do so, 
+possible to set a *version override* that will use a different version instead of the last git tag. To do so,
 use the
 
 ```

--- a/changelog/@unreleased/pr-230.v2.yml
+++ b/changelog/@unreleased/pr-230.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: '`./gradlew revapiAcceptAllBreaks` no longer fails when a repo contains
+    a project which has never been published before.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/230

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -127,13 +127,7 @@ public final class RevapiPlugin implements Plugin<Project> {
             task.getOldGroupNameVersion().set(project.getProviders().provider(extension::oldGroupNameVersion));
             task.getConfigManager().set(configManager);
             task.getAnalysisResultsFile().set(analyzeTask.flatMap(RevapiAnalyzeTask::getAnalysisResultsFile));
-            task.onlyIf(new Spec<Task>() {
-                @Override
-                public boolean isSatisfiedBy(Task _task) {
-                    File file = analyzeTask.get().getAnalysisResultsFile().get().getAsFile();
-                    return file.exists();
-                }
-            });
+            task.onlyIf(oldApiIsPresent);
         });
 
         project.getTasks().register(VERSION_OVERRIDE_TASK_NAME, RevapiVersionOverrideTask.class, task -> {

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -127,6 +127,12 @@ public final class RevapiPlugin implements Plugin<Project> {
             task.getOldGroupNameVersion().set(project.getProviders().provider(extension::oldGroupNameVersion));
             task.getConfigManager().set(configManager);
             task.getAnalysisResultsFile().set(analyzeTask.flatMap(RevapiAnalyzeTask::getAnalysisResultsFile));
+            task.onlyIf(new Spec<Task>() {
+                @Override
+                public boolean isSatisfiedBy(Task _task) {
+                    return analyzeTask.get().getAnalysisResultsFile().get().getAsFile().exists();
+                }
+            });
         });
 
         project.getTasks().register(VERSION_OVERRIDE_TASK_NAME, RevapiVersionOverrideTask.class, task -> {

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -130,7 +130,8 @@ public final class RevapiPlugin implements Plugin<Project> {
             task.onlyIf(new Spec<Task>() {
                 @Override
                 public boolean isSatisfiedBy(Task _task) {
-                    return analyzeTask.get().getAnalysisResultsFile().get().getAsFile().exists();
+                    File file = analyzeTask.get().getAnalysisResultsFile().get().getAsFile();
+                    return file.exists();
                 }
             });
         });

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -339,8 +339,8 @@ class RevapiSpec extends IntegrationSpec {
         writeHelloWorld()
 
         then:
-        def executionResult = runTasksSuccessfully('revapiAcceptBreak')
-        executionResult.wasSkipped(':revapiAnalyze')
+        def executionResult = runTasksSuccessfully('revapiAcceptBreak', '--justification', 'foo', '--code', 'bar',
+                '--old', 'old', '--new', 'new')
         executionResult.wasSkipped(':revapiAcceptBreak')
     }
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -311,8 +311,40 @@ class RevapiSpec extends IntegrationSpec {
         assert standardError.contains('willBeRemoved')
     }
 
-    def 'if there are no published versions of the library at all, dont error out'() {
+    def 'if there are no published versions of the library at all, ./gradlew revapi doesnt fail'() {
         when:
+        setupUnpublishedLibrary()
+        writeHelloWorld()
+
+        then:
+        def executionResult = runTasksSuccessfully('revapi')
+        executionResult.wasSkipped(':revapiAnalyze')
+        executionResult.wasSkipped(':revapi')
+    }
+
+    def 'if there are no published versions of the library at all, ./gradlew revapiAcceptAllBreaks is a no-op'() {
+        when:
+        setupUnpublishedLibrary()
+        writeHelloWorld()
+
+        then:
+        def executionResult = runTasksSuccessfully('revapiAcceptAllBreaks')
+        executionResult.wasSkipped(':revapiAnalyze')
+        executionResult.wasSkipped(':revapiAcceptAllBreaks')
+    }
+
+    def 'if there are no published versions of the library at all, ./gradlew revapiAcceptBreak is a no-op'() {
+        when:
+        setupUnpublishedLibrary()
+        writeHelloWorld()
+
+        then:
+        def executionResult = runTasksSuccessfully('revapiAcceptBreak')
+        executionResult.wasSkipped(':revapiAnalyze')
+        executionResult.wasSkipped(':revapiAcceptBreak')
+    }
+
+    private File setupUnpublishedLibrary() {
         buildFile << """
             apply plugin: '${TestConstants.PLUGIN_NAME}'
             apply plugin: 'java-library'
@@ -327,13 +359,6 @@ class RevapiSpec extends IntegrationSpec {
                 oldVersion = '1.0.0'
             }
         """.stripIndent()
-
-        writeHelloWorld()
-
-        then:
-        def executionResult = runTasksSuccessfully('revapi')
-        executionResult.wasSkipped(':revapiAnalyze')
-        executionResult.wasSkipped(':revapi')
     }
 
     def 'handles the output of extra source sets being added to compile configuration'() {

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -333,7 +333,7 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapiAcceptAllBreaks')
     }
 
-    def 'if there are no published versions of the library at all, ./gradlew revapiAcceptBreak is a no-op'() {
+    def 'if there are no published versions of the library at all, ./gradlew revapiAcceptBreak doesnt fail'() {
         when:
         setupUnpublishedLibrary()
         writeHelloWorld()
@@ -341,7 +341,7 @@ class RevapiSpec extends IntegrationSpec {
         then:
         def executionResult = runTasksSuccessfully('revapiAcceptBreak', '--justification', 'foo', '--code', 'bar',
                 '--old', 'old', '--new', 'new')
-        executionResult.wasSkipped(':revapiAcceptBreak')
+        executionResult.wasExecuted(':revapiAcceptBreak')
     }
 
     private File setupUnpublishedLibrary() {


### PR DESCRIPTION
## Before this PR

We got a report in #dev-foundry-infra from @jroitgrund. Think this is a follow up to @CRogers earlier PR https://github.com/palantir/gradle-revapi/pull/223. 

He needed to accept breaks that were made in 9 gradle projects, but also had one newly added project which had not yet been published. Invoking `./gradlew revapiAcceptAllBreaks` at the repo root broke.

## After this PR
==COMMIT_MSG==
`./gradlew revapiAcceptAllBreaks` no longer fails when a repo contains a project which has never been published before.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

