### PR TITLE
Ensure we don't find breaks in api dependencies needlessly

### DIFF
--- a/changelog/@unreleased/pr-238.v2.yml
+++ b/changelog/@unreleased/pr-238.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fixes a bug introduced in 1.3.2 where breaks for `api` dependencies
+    would be spuriously reported.
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/238

--- a/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
+++ b/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
@@ -102,7 +102,7 @@ final class ResolveOldApi {
         Set<File> oldWithDeps = OldApiConfigurations.resolveOldConfiguration(project, groupNameVersion, true);
 
         Set<File> oldJustDeps = new HashSet<>(oldWithDeps);
-        oldJustDeps.removeAll(oldWithDeps);
+        oldJustDeps.removeAll(oldOnlyJar);
 
         return OldApi.builder().jars(oldOnlyJar).dependencyJars(oldJustDeps).build();
     }


### PR DESCRIPTION
## Before this PR
Thanks to a bug introduced in #214, the set of old deps is always empty. This means revapi always thinks there are breaks in interfaces, as they have had all of the methods added.

## After this PR
==COMMIT_MSG==
Fixes a bug introduced in 1.3.2 where breaks for `api` dependencies would be spuriously reported.
==COMMIT_MSG==

