### PR TITLE
Compatibility with gradle-shadow-jar

### DIFF
--- a/changelog/@unreleased/pr-247.v2.yml
+++ b/changelog/@unreleased/pr-247.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Shaded classes placed in the top level `shadow` package are no longer
+    identified as breaks (this makes `gradle-revapi` compatible with `gradle-shadow-jar`
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/247

--- a/src/main/resources/revapi-configuration.json
+++ b/src/main/resources/revapi-configuration.json
@@ -6,7 +6,10 @@
       "filter": {
         "classes": {
           "regex": true,
-          "exclude": [".*\\$$"]
+          "exclude": [
+            ".*\\$$",
+            "^shadow.*"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Before this PR
The soon to be open sourced `gradle-shadow-jar` plugin allows automatic partial shading of dependencies, by putting the shaded classes under a root package `shadow`. `gradle-revapi` tells you that these shaded classes have been lost, despite the fact they are not part of the public API of the jar.

## After this PR
==COMMIT_MSG==
Shaded classes placed in the top level `shadow` package are no longer identified as breaks (this makes `gradle-revapi` compatible with `gradle-shadow-jar`
==COMMIT_MSG==

## Possible downsides?
Spuriously ignoring unshaded deps that have been put in `shadow` top level package - this would be a seriously weird thing for someone to do.

