### PR TITLE
Understand immutables

### DIFF
--- a/changelog/@unreleased/pr-248.v2.yml
+++ b/changelog/@unreleased/pr-248.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: '`gradle-revapi` understands [`immutables`](https://immutables.github.io/)
+    classes and will not raise a break if an abstract method has been added to an
+    immutables class, or a protected abstract method changed.'
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/248

--- a/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
+++ b/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
@@ -36,8 +36,10 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
 
     private static final String ABSTRACT_METHOD_ADDED = "java.method.abstractMethodAdded";
     private static final String RETURN_TYPE_CHANGED = "java.method.returnTypeChanged";
+    private static final String VISIBILITY_REDUCED = "java.method.visibilityReduced";
 
-    private static final Pattern[] DIFFERENCE_CODE_PATTERNS = Stream.of(ABSTRACT_METHOD_ADDED, RETURN_TYPE_CHANGED)
+    private static final Pattern[] DIFFERENCE_CODE_PATTERNS = Stream.of(
+                    ABSTRACT_METHOD_ADDED, RETURN_TYPE_CHANGED, VISIBILITY_REDUCED)
             .map(Pattern::compile)
             .toArray(Pattern[]::new);
 
@@ -61,7 +63,7 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
             @Nullable JavaElement oldElement, @Nullable JavaElement newElement, @Nonnull Difference difference) {
         switch (difference.code) {
             case ABSTRACT_METHOD_ADDED:
-                if (isMethodInImmutablesClass(oldElement) || isMethodInImmutablesClass(newElement)) {
+                if (isMethodInImmutablesClass(newElement)) {
                     // if the element is an immutables class, ignore the difference
                     return null;
                 }
@@ -69,6 +71,7 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
                 // otherwise return it as is
                 return difference;
             case RETURN_TYPE_CHANGED:
+            case VISIBILITY_REDUCED:
                 if (isMethodInImmutablesClass(oldElement)
                         && isMethodInImmutablesClass(newElement)
                         && abstractNonPublic(oldElement)) {

--- a/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
+++ b/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
@@ -57,7 +57,7 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
     }
 
     @Override
-    public void initialize(@Nonnull AnalysisContext analysisContext) {}
+    public void initialize(@Nonnull AnalysisContext _analysisContext) {}
 
     @Nullable
     @Override
@@ -84,7 +84,7 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
                 return inImmutablesClass(oldElement) && abstractNonPublic(oldElement);
 
             case METHOD_NOW_ABSTRACT:
-                return inImmutablesClass(newElement) && inImmutablesClass(newElement);
+                return inImmutablesClass(oldElement) && inImmutablesClass(newElement);
         }
 
         return false;

--- a/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
+++ b/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
@@ -39,7 +39,8 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
                     Code.METHOD_ABSTRACT_METHOD_ADDED,
                     Code.METHOD_RETURN_TYPE_CHANGED,
                     Code.METHOD_VISIBILITY_REDUCED,
-                    Code.METHOD_NOW_ABSTRACT)
+                    Code.METHOD_NOW_ABSTRACT,
+                    Code.METHOD_REMOVED)
             .map(Code::code)
             .map(Pattern::compile)
             .toArray(Pattern[]::new);
@@ -78,6 +79,9 @@ public final class ImmutablesFilter implements DifferenceTransform<JavaElement> 
             case METHOD_RETURN_TYPE_CHANGED:
             case METHOD_VISIBILITY_REDUCED:
                 return inImmutablesClass(oldElement) && inImmutablesClass(newElement) && abstractNonPublic(oldElement);
+
+            case METHOD_REMOVED:
+                return inImmutablesClass(oldElement) && abstractNonPublic(oldElement);
 
             case METHOD_NOW_ABSTRACT:
                 return inImmutablesClass(newElement) && inImmutablesClass(newElement);

--- a/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
+++ b/src/main/java/com/palantir/gradle/revapi/ImmutablesFilter.java
@@ -1,0 +1,101 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.revapi;
+
+import java.io.Reader;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+import org.revapi.AnalysisContext;
+import org.revapi.Difference;
+import org.revapi.DifferenceTransform;
+import org.revapi.java.model.MethodElement;
+import org.revapi.java.spi.JavaElement;
+
+public final class ImmutablesFilter implements DifferenceTransform<JavaElement> {
+    private static final String EXTENSION_ID = "gradle-revapi.immutables";
+    public static final RevapiConfig CONFIG = RevapiConfig.empty().withExtension(EXTENSION_ID);
+
+    private static final Pattern[] DIFFERENCE_CODE_PATTERNS = Stream.of(
+                    "java.method.abstractMethodAdded", "java.method.returnTypeChanged")
+            .map(Pattern::compile)
+            .toArray(Pattern[]::new);
+
+    @Override
+    public String getExtensionId() {
+        return EXTENSION_ID;
+    }
+
+    @Nonnull
+    @Override
+    public Pattern[] getDifferenceCodePatterns() {
+        return DIFFERENCE_CODE_PATTERNS;
+    }
+
+    @Override
+    public void initialize(@Nonnull AnalysisContext analysisContext) {}
+
+    @Nullable
+    @Override
+    public Difference transform(
+            @Nullable JavaElement oldElement, @Nullable JavaElement newElement, @Nonnull Difference difference) {
+        if (isNonPublicAbstractMethodInImmutablesClass(oldElement)
+                || isNonPublicAbstractMethodInImmutablesClass(newElement)) {
+            // if the element is an immutables class, ignore the difference
+            return null;
+        }
+
+        // otherwise return it as is
+        return difference;
+    }
+
+    private static boolean isNonPublicAbstractMethodInImmutablesClass(JavaElement javaElement) {
+        if (javaElement == null) {
+            return false;
+        }
+
+        if (!(javaElement instanceof MethodElement)) {
+            return false;
+        }
+
+        MethodElement methodElement = (MethodElement) javaElement;
+
+        boolean isImmutable = methodElement.getDeclaringElement().getEnclosingElement().getAnnotationMirrors().stream()
+                .anyMatch(annotationMirror ->
+                        annotationMirror.toString().equals("@org.immutables.value.Value.Immutable"));
+
+        if (!isImmutable) {
+            return false;
+        }
+
+        boolean isAbstract = methodElement.getDeclaringElement().getModifiers().contains(Modifier.ABSTRACT);
+        boolean isPublic = methodElement.getDeclaringElement().getModifiers().contains(Modifier.PUBLIC);
+
+        return isPublic && !isAbstract;
+    }
+
+    @Nullable
+    @Override
+    public Reader getJSONSchema() {
+        return null;
+    }
+
+    @Override
+    public void close() {}
+}

--- a/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiAnalyzeTask.java
@@ -110,7 +110,7 @@ public class RevapiAnalyzeTask extends DefaultTask {
                 .withAllExtensionsFromThreadContextClassLoader()
                 .withAnalyzers(JavaApiAnalyzer.class)
                 .withReporters(TextReporter.class)
-                .withTransforms(CheckWhitelist.class)
+                .withTransforms(CheckWhitelist.class, ImmutablesFilter.class)
                 .build();
 
         RevapiConfig revapiConfig = RevapiConfig.mergeAll(
@@ -120,7 +120,8 @@ public class RevapiAnalyzeTask extends DefaultTask {
                                 "gradle-revapi-results.ftl",
                                 analysisResultsFile.getAsFile().get()),
                 revapiIgnores(),
-                ConjureProjectFilters.forProject(getProject()));
+                ConjureProjectFilters.forProject(getProject()),
+                ImmutablesFilter.CONFIG);
 
         log.info("revapi config:\n{}", revapiConfig.configAsString());
 

--- a/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiConfig.java
@@ -64,6 +64,10 @@ abstract class RevapiConfig {
         return withExtension("revapi.ignore", OBJECT_MAPPER.convertValue(acceptedBreaks, ArrayNode.class));
     }
 
+    public RevapiConfig withExtension(String extensionId) {
+        return withExtension(extensionId, OBJECT_MAPPER.createObjectNode());
+    }
+
     public RevapiConfig withExtension(String extensionId, JsonNode configuration) {
         JsonNode extension =
                 OBJECT_MAPPER.createObjectNode().put("extension", extensionId).set("configuration", configuration);

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -899,12 +899,15 @@ class RevapiSpec extends IntegrationSpec {
                 public abstract long reducedVisibilityPublicParam();
                 protected abstract long reducedVisibilityProtectedParam();
                 public abstract long noLongerAbstractPublicParam();
+                protected abstract long removedProtectedParam();
                 
                 public long nowAbstractPublicMethod() { return 3L; }
                 
                 public String returnTypeChangedPublicMethod() {
                     return null;
                 }
+                
+                public void removedPublicMethod() {}
             }
         '''.stripIndent()
 
@@ -927,6 +930,10 @@ class RevapiSpec extends IntegrationSpec {
                 .replace(
                         'public long nowAbstractPublicMethod() { return 3L; }',
                         'public abstract long nowAbstractPublicMethod();')
+                .replace(
+                        'protected abstract long removedProtectedParam();',
+                        '')
+                .replace('public void removedPublicMethod() {}', '')
 
         then:
         def executionResult = runTasks('revapi')
@@ -940,11 +947,13 @@ class RevapiSpec extends IntegrationSpec {
         !errorMessage.contains('reducedVisibilityProtectedParam()')
         !errorMessage.contains('noLongerAbstractPublicParam()')
         !errorMessage.contains('nowAbstractPublicMethod()')
+        !errorMessage.contains('removedProtectedParam()')
 
         errorMessage.contains('returnTypeChangedPublicParam()')
         errorMessage.contains('returnTypeChangedPublicMethod()')
         errorMessage.contains('removedPublicParam()')
         errorMessage.contains('reducedVisibilityPublicParam()')
+        errorMessage.contains('removedPublicMethod()')
 
     }
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -907,7 +907,7 @@ class RevapiSpec extends IntegrationSpec {
 
         immutablesClass.text = immutablesClass.text
                 .replaceAll('String', 'Integer')
-                .replaceAll('// add new public param here', 'public abstract String newPublicParam();')
+                .replaceAll('// add new public param here', 'public abstract String newParamThatIsPublic();')
 
         then:
         def executionResult = runTasks('revapi')
@@ -916,7 +916,7 @@ class RevapiSpec extends IntegrationSpec {
 
         def errorMessage = executionResult.failure.cause.cause.message
         !errorMessage.contains('protectedParam')
-        !errorMessage.contains('newPublicParam')
+        !errorMessage.contains('newParamThatIsPublic')
         errorMessage.contains('publicParam')
         errorMessage.contains('publicMethod')
 

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -898,6 +898,9 @@ class RevapiSpec extends IntegrationSpec {
                 public abstract long removedPublicParam();
                 public abstract long reducedVisibilityPublicParam();
                 protected abstract long reducedVisibilityProtectedParam();
+                public abstract long noLongerAbstractPublicParam();
+                
+                public long nowAbstractPublicMethod() { return 3L; }
                 
                 public String returnTypeChangedPublicMethod() {
                     return null;
@@ -918,6 +921,12 @@ class RevapiSpec extends IntegrationSpec {
                 .replace(
                         'protected abstract long reducedVisibilityProtectedParam();',
                         'abstract long reducedVisibilityProtectedParam();')
+                .replace(
+                        'public abstract long noLongerAbstractPublicParam()',
+                        'public long noLongerAbstractPublicParam() { return 1L; }')
+                .replace(
+                        'public long nowAbstractPublicMethod() { return 3L; }',
+                        'public abstract long nowAbstractPublicMethod();')
 
         then:
         def executionResult = runTasks('revapi')
@@ -929,6 +938,8 @@ class RevapiSpec extends IntegrationSpec {
         !errorMessage.contains('returnTypeChangedProtectedParam()')
         !errorMessage.contains('newPublicParam()')
         !errorMessage.contains('reducedVisibilityProtectedParam()')
+        !errorMessage.contains('noLongerAbstractPublicParam()')
+        !errorMessage.contains('nowAbstractPublicMethod()')
 
         errorMessage.contains('returnTypeChangedPublicParam()')
         errorMessage.contains('returnTypeChangedPublicMethod()')


### PR DESCRIPTION
## Before this PR
When using [`immutables`](https://immutables.github.io/), Revapi does not understand that the expectation is that users do not implement the abstract types that you use to define immutables, so complains that you have added new methods or changed existing protected methods.

## After this PR
==COMMIT_MSG==
`gradle-revapi` understands [`immutables`](https://immutables.github.io/) classes and will not raise a break if an abstract method has been added to an immutables class, or a protected abstract method changed.
==COMMIT_MSG==

## Possible downsides?
Technically, users can still implement these abstract immutables classes, and it's technically a break.

