### PR TITLE
Test to show that the revapi plugin has problems with gradle-consiste…

### DIFF
--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -20,7 +20,6 @@ import java.util.regex.Pattern
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.util.environment.RestoreSystemProperties
-import spock.lang.Ignore
 
 class RevapiSpec extends IntegrationSpec {
     private Git git
@@ -29,7 +28,6 @@ class RevapiSpec extends IntegrationSpec {
         git = new Git(projectDir)
     }
 
-    @Ignore
     def 'fails when comparing produced jar versus some random other jar'() {
         when:
         buildFile << """
@@ -65,7 +63,6 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
-    @Ignore
     def 'revapi task succeeds when there are no breaking changes'() {
         when:
         buildFile << """
@@ -87,7 +84,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
-    @Ignore
     def 'doesnt explode when project code depends on compileOnly dependency'() {
         when:
         buildFile << """
@@ -132,7 +128,6 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.rethrowFailure()
     }
 
-    @Ignore
     def 'revapiAcceptAllBreaks succeeds when there are no breaking changes'() {
         when:
         buildFile << """
@@ -154,7 +149,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapiAcceptAllBreaks", "--justification", "fight me")
     }
 
-    @Ignore
     def 'does not error out when project has a version greater than the "old version"'() {
         def revapi = 'revapi'
 
@@ -188,7 +182,6 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences(revapi)
     }
 
-    @Ignore
     def 'errors out when the old api dependency does not exist but then works once you run the version override task'() {
         when:
         buildFile << """
@@ -215,7 +208,6 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
-    @Ignore
     def 'errors out when the target dependency does not exist and we do not give an version override'() {
         when:
         buildFile << """
@@ -239,7 +231,6 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingResolutionFailure()
     }
 
-    @Ignore
     def 'skips revapi tasks when the versions to check is empty list'() {
         when:
         buildFile << """
@@ -263,7 +254,6 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapi')
     }
 
-    @Ignore
     def 'when the previous git tag has failed to publish, it will look back up to a further git tag'() {
         when:
         git.initWithTestUser()
@@ -321,7 +311,6 @@ class RevapiSpec extends IntegrationSpec {
         assert standardError.contains('willBeRemoved')
     }
 
-    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapi doesnt fail'() {
         when:
         setupUnpublishedLibrary()
@@ -333,7 +322,6 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapi')
     }
 
-    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapiAcceptAllBreaks is a no-op'() {
         when:
         setupUnpublishedLibrary()
@@ -345,7 +333,6 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapiAcceptAllBreaks')
     }
 
-    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapiAcceptBreak doesnt fail'() {
         when:
         setupUnpublishedLibrary()
@@ -374,7 +361,6 @@ class RevapiSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    @Ignore
     def 'handles the output of extra source sets being added to compile configuration'() {
         when:
         buildFile << """
@@ -406,7 +392,6 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
-    @Ignore
     def 'errors out when there are breaks but then is fine when breaks are accepted'() {
         when:
         buildFile << """
@@ -436,7 +421,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
-    @Ignore
     def 'accepting breaks individually should work'() {
         when:
         buildFile << """
@@ -484,7 +468,6 @@ class RevapiSpec extends IntegrationSpec {
 
     }
 
-    @Ignore
     def 'moving a class from one project to a dependent project is not a break (only if it is in the api configuration)'() {
         buildFile << """
             allprojects {
@@ -535,7 +518,6 @@ class RevapiSpec extends IntegrationSpec {
         assert runRevapiExpectingFailure().contains('java.class.removed')
     }
 
-    @Ignore
     def 'ignores breaks in dependent projects'() {
         when:
         buildFile << """
@@ -587,7 +569,6 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
-    @Ignore
     def 'should not say there are breaks in api dependencies when nothing has changed'() {
         when:
         rootProjectNameIs('test')
@@ -629,7 +610,6 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
-    @Ignore
     def 'ignores scala classes'() {
         when:
         buildFile << """
@@ -651,7 +631,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
-    @Ignore
     def 'ignores magic methods added by groovy when comparing the same groovy class'() {
         when:
         buildFile << """
@@ -688,7 +667,6 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
-    @Ignore
     def 'detects breaks in groovy code'() {
         when:
         buildFile << """
@@ -739,7 +717,6 @@ class RevapiSpec extends IntegrationSpec {
         assert stderr.contains('method void foo.Foo::setSomeProperty(java.lang.String)')
     }
 
-    @Ignore
     def 'does not throw exception when baseline-circleci is applied before this plugin'() {
         when:
         addSubproject 'subproject',  """
@@ -768,7 +745,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("tasks")
     }
 
-    @Ignore
     def 'is up to date when nothing has changed after running once'() {
         when:
         buildFile << """
@@ -791,7 +767,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully('revapi').wasUpToDate('revapiAnalyze')
     }
 
-    @Ignore
     def 'is not up to date when public (not private) api has changed'() {
         when:
         buildFile << """
@@ -839,7 +814,6 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully('revapi').wasExecuted('revapiAnalyze')
     }
 
-    @Ignore
     def 'compatible with gradle-shadow-jar'() {
         when:
         rootProjectNameIs('root')
@@ -878,7 +852,6 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully('revapi').standardOutput
     }
 
-    @Ignore
     def 'changing a protected method in an immutables class is not a break'() {
         when:
         rootProjectNameIs('root')
@@ -1006,7 +979,6 @@ class RevapiSpec extends IntegrationSpec {
         }
     }
 
-    @Ignore
     @RestoreSystemProperties
     def 'breaks detected in conjure projects should be limited to those which break java but are not caught by conjure-backcompat'() {
         when:

--- a/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
+++ b/src/test/groovy/com/palantir/gradle/revapi/RevapiSpec.groovy
@@ -16,11 +16,11 @@
 
 package com.palantir.gradle.revapi
 
-
 import java.util.regex.Pattern
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 import spock.util.environment.RestoreSystemProperties
+import spock.lang.Ignore
 
 class RevapiSpec extends IntegrationSpec {
     private Git git
@@ -29,6 +29,7 @@ class RevapiSpec extends IntegrationSpec {
         git = new Git(projectDir)
     }
 
+    @Ignore
     def 'fails when comparing produced jar versus some random other jar'() {
         when:
         buildFile << """
@@ -64,6 +65,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
+    @Ignore
     def 'revapi task succeeds when there are no breaking changes'() {
         when:
         buildFile << """
@@ -85,6 +87,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
+    @Ignore
     def 'doesnt explode when project code depends on compileOnly dependency'() {
         when:
         buildFile << """
@@ -129,6 +132,7 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.rethrowFailure()
     }
 
+    @Ignore
     def 'revapiAcceptAllBreaks succeeds when there are no breaking changes'() {
         when:
         buildFile << """
@@ -150,6 +154,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapiAcceptAllBreaks", "--justification", "fight me")
     }
 
+    @Ignore
     def 'does not error out when project has a version greater than the "old version"'() {
         def revapi = 'revapi'
 
@@ -183,6 +188,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences(revapi)
     }
 
+    @Ignore
     def 'errors out when the old api dependency does not exist but then works once you run the version override task'() {
         when:
         buildFile << """
@@ -209,6 +215,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
+    @Ignore
     def 'errors out when the target dependency does not exist and we do not give an version override'() {
         when:
         buildFile << """
@@ -232,6 +239,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingResolutionFailure()
     }
 
+    @Ignore
     def 'skips revapi tasks when the versions to check is empty list'() {
         when:
         buildFile << """
@@ -255,6 +263,7 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapi')
     }
 
+    @Ignore
     def 'when the previous git tag has failed to publish, it will look back up to a further git tag'() {
         when:
         git.initWithTestUser()
@@ -312,6 +321,7 @@ class RevapiSpec extends IntegrationSpec {
         assert standardError.contains('willBeRemoved')
     }
 
+    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapi doesnt fail'() {
         when:
         setupUnpublishedLibrary()
@@ -323,6 +333,7 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapi')
     }
 
+    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapiAcceptAllBreaks is a no-op'() {
         when:
         setupUnpublishedLibrary()
@@ -334,6 +345,7 @@ class RevapiSpec extends IntegrationSpec {
         executionResult.wasSkipped(':revapiAcceptAllBreaks')
     }
 
+    @Ignore
     def 'if there are no published versions of the library at all, ./gradlew revapiAcceptBreak doesnt fail'() {
         when:
         setupUnpublishedLibrary()
@@ -362,6 +374,7 @@ class RevapiSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
+    @Ignore
     def 'handles the output of extra source sets being added to compile configuration'() {
         when:
         buildFile << """
@@ -393,6 +406,7 @@ class RevapiSpec extends IntegrationSpec {
         runRevapiExpectingToFindDifferences("root-project")
     }
 
+    @Ignore
     def 'errors out when there are breaks but then is fine when breaks are accepted'() {
         when:
         buildFile << """
@@ -422,6 +436,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
+    @Ignore
     def 'accepting breaks individually should work'() {
         when:
         buildFile << """
@@ -469,6 +484,7 @@ class RevapiSpec extends IntegrationSpec {
 
     }
 
+    @Ignore
     def 'moving a class from one project to a dependent project is not a break (only if it is in the api configuration)'() {
         buildFile << """
             allprojects {
@@ -519,6 +535,7 @@ class RevapiSpec extends IntegrationSpec {
         assert runRevapiExpectingFailure().contains('java.class.removed')
     }
 
+    @Ignore
     def 'ignores breaks in dependent projects'() {
         when:
         buildFile << """
@@ -570,6 +587,7 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
+    @Ignore
     def 'should not say there are breaks in api dependencies when nothing has changed'() {
         when:
         rootProjectNameIs('test')
@@ -611,6 +629,7 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
+    @Ignore
     def 'ignores scala classes'() {
         when:
         buildFile << """
@@ -632,6 +651,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("revapi")
     }
 
+    @Ignore
     def 'ignores magic methods added by groovy when comparing the same groovy class'() {
         when:
         buildFile << """
@@ -668,6 +688,7 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully("revapi").standardOutput
     }
 
+    @Ignore
     def 'detects breaks in groovy code'() {
         when:
         buildFile << """
@@ -718,6 +739,7 @@ class RevapiSpec extends IntegrationSpec {
         assert stderr.contains('method void foo.Foo::setSomeProperty(java.lang.String)')
     }
 
+    @Ignore
     def 'does not throw exception when baseline-circleci is applied before this plugin'() {
         when:
         addSubproject 'subproject',  """
@@ -746,6 +768,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully("tasks")
     }
 
+    @Ignore
     def 'is up to date when nothing has changed after running once'() {
         when:
         buildFile << """
@@ -768,6 +791,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully('revapi').wasUpToDate('revapiAnalyze')
     }
 
+    @Ignore
     def 'is not up to date when public (not private) api has changed'() {
         when:
         buildFile << """
@@ -815,6 +839,7 @@ class RevapiSpec extends IntegrationSpec {
         runTasksSuccessfully('revapi').wasExecuted('revapiAnalyze')
     }
 
+    @Ignore
     def 'compatible with gradle-shadow-jar'() {
         when:
         rootProjectNameIs('root')
@@ -853,6 +878,7 @@ class RevapiSpec extends IntegrationSpec {
         println runTasksSuccessfully('revapi').standardOutput
     }
 
+    @Ignore
     def 'changing a protected method in an immutables class is not a break'() {
         when:
         rootProjectNameIs('root')
@@ -980,6 +1006,7 @@ class RevapiSpec extends IntegrationSpec {
         }
     }
 
+    @Ignore
     @RestoreSystemProperties
     def 'breaks detected in conjure projects should be limited to those which break java but are not caught by conjure-backcompat'() {
         when:
@@ -1119,6 +1146,79 @@ class RevapiSpec extends IntegrationSpec {
 
         runTasksSuccessfully(':api-undertow:revapi')
     }
+
+    def 'revapi task is compatible with gradle-consistent-versions'() {
+        when:
+        git.initWithTestUser()
+
+        writeToFile '.gitignore', """
+            .gradle*/
+            build/
+            mavenRepo/
+        """.stripIndent()
+
+        rootProjectNameIs 'name'
+
+        buildFile << """
+            plugins {
+                id 'com.palantir.git-version' version '0.12.2'
+                id 'com.palantir.consistent-versions' version '1.26.0'
+            }
+
+            allprojects {            
+                group = 'group'
+                version = gitVersion()
+
+                repositories {
+                    mavenCentral()
+                }
+            }
+            
+            subprojects {
+                apply plugin: 'java-library'
+            }
+        """.stripIndent()
+
+        new File(projectDir, 'versions.props') << """
+            one.util:streamex = 0.7.0
+        """.stripIndent()
+        new File(projectDir, 'versions.lock') << """
+            # Run ./gradlew --write-locks to regenerate this file
+            one.util:streamex:0.7.0 (1 constraints: 09050036)
+        """.stripIndent().stripLeading()
+
+        def one = addSubproject 'one', """
+            apply plugin: '${TestConstants.PLUGIN_NAME}'
+            apply plugin: 'maven-publish'
+            
+            dependencies {
+                compile 'one.util:streamex'
+            }
+
+            ${mavenRepoGradle()}
+            ${testMavenPublication()}            
+        """.stripIndent()
+
+        def javaFile = 'src/main/java/foo/Foo.java'
+        writeToFile one, javaFile, """
+            public interface Foo {
+                String willBeRemoved();
+            }
+        """.stripIndent()
+
+        git.command 'git add .'
+        git.command 'git commit -m 0.1.0'
+        git.command 'git tag 0.1.0'
+
+        runTasksSuccessfully('publish')
+
+        and:
+        git.command 'git commit --allow-empty -am new-work'
+
+        then:
+        runTasksSuccessfully('revapi')
+    }
+
 
     static class MethodChange {
         final String oldText


### PR DESCRIPTION
…nt-versions

## Before this PR
The Gradle revapi plugin throws the following exception when run with gradle-consistent-versions and in a subproject:

```
org.gradle.api.GradleException: Build aborted because of an internal error.
	at nebula.test.functional.internal.DefaultExecutionResult.rethrowFailure(DefaultExecutionResult.groovy:97)
	at com.palantir.gradle.revapi.RevapiSpec.runTasksSuccessfully(RevapiSpec.groovy:1317)
	at com.palantir.gradle.revapi.RevapiSpec.revapi task is compatible with gradle-consistent-versions(RevapiSpec.groovy:1223)
Caused by: org.gradle.internal.exceptions.LocationAwareException: Could not determine the dependencies of task ':one:revapiAnalyze'.
	at org.gradle.initialization.exception.DefaultExceptionAnalyser.transform(DefaultExceptionAnalyser.java:99)
	at org.gradle.initialization.exception.DefaultExceptionAnalyser.collectFailures(DefaultExceptionAnalyser.java:65)
	at org.gradle.initialization.exception.MultipleBuildFailuresExceptionAnalyser.transform(MultipleBuildFailuresExceptionAnalyser.java:48)
	at org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser.transform(StackTraceSanitizingExceptionAnalyser.java:30)
	at org.gradle.initialization.DefaultGradleLauncher.finishBuild(DefaultGradleLauncher.java:162)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:129)
	at org.gradle.initialization.DefaultGradleLauncher.executeTasks(DefaultGradleLauncher.java:106)
	at org.gradle.internal.invocation.GradleBuildController$1.execute(GradleBuildController.java:60)
	at org.gradle.internal.invocation.GradleBuildController$1.execute(GradleBuildController.java:57)
	at org.gradle.internal.invocation.GradleBuildController$3.create(GradleBuildController.java:85)
	at org.gradle.internal.invocation.GradleBuildController$3.create(GradleBuildController.java:78)
	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:189)
	at org.gradle.internal.work.StopShieldingWorkerLeaseService.withLocks(StopShieldingWorkerLeaseService.java:40)
	at org.gradle.internal.invocation.GradleBuildController.doBuild(GradleBuildController.java:78)
	at org.gradle.internal.invocation.GradleBuildController.run(GradleBuildController.java:57)
	at org.gradle.tooling.internal.provider.runner.BuildModelActionRunner.run(BuildModelActionRunner.java:54)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner.run(BuildOutcomeReportingBuildActionRunner.java:63)
	at org.gradle.tooling.internal.provider.ValidatingBuildActionRunner.run(ValidatingBuildActionRunner.java:32)
	at org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner.run(BuildCompletionNotifyingBuildActionRunner.java:39)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner$3.call(RunAsBuildOperationBuildActionRunner.java:51)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner$3.call(RunAsBuildOperationBuildActionRunner.java:45)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:416)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:406)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:102)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.call(DelegatingBuildOperationExecutor.java:36)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner.run(RunAsBuildOperationBuildActionRunner.java:45)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter$1.transform(InProcessBuildActionExecuter.java:50)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter$1.transform(InProcessBuildActionExecuter.java:47)
	at org.gradle.composite.internal.DefaultRootBuildState.run(DefaultRootBuildState.java:78)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:47)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:31)
	at org.gradle.launcher.exec.BuildTreeScopeBuildActionExecuter.execute(BuildTreeScopeBuildActionExecuter.java:42)
	at org.gradle.launcher.exec.BuildTreeScopeBuildActionExecuter.execute(BuildTreeScopeBuildActionExecuter.java:28)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:78)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:52)
	at org.gradle.tooling.internal.provider.SubscribableBuildActionExecuter.execute(SubscribableBuildActionExecuter.java:59)
	at org.gradle.tooling.internal.provider.SubscribableBuildActionExecuter.execute(SubscribableBuildActionExecuter.java:36)
	at org.gradle.tooling.internal.provider.SessionScopeBuildActionExecuter.execute(SessionScopeBuildActionExecuter.java:68)
	at org.gradle.tooling.internal.provider.SessionScopeBuildActionExecuter.execute(SessionScopeBuildActionExecuter.java:38)
	at org.gradle.tooling.internal.provider.GradleThreadBuildActionExecuter.execute(GradleThreadBuildActionExecuter.java:37)
	at org.gradle.tooling.internal.provider.GradleThreadBuildActionExecuter.execute(GradleThreadBuildActionExecuter.java:26)
	at org.gradle.tooling.internal.provider.ParallelismConfigurationBuildActionExecuter.execute(ParallelismConfigurationBuildActionExecuter.java:43)
	at org.gradle.tooling.internal.provider.ParallelismConfigurationBuildActionExecuter.execute(ParallelismConfigurationBuildActionExecuter.java:29)
	at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:60)
	at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:32)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:55)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:41)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:48)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:32)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter$1.create(StdInSwapExecuter.java:44)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter$1.create(StdInSwapExecuter.java:41)
	at org.gradle.util.Swapper.swap(Swapper.java:38)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter.execute(StdInSwapExecuter.java:41)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter.execute(StdInSwapExecuter.java:30)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:51)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:35)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:60)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:38)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:193)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:136)
	at org.gradle.tooling.internal.provider.DefaultConnection.getModel(DefaultConnection.java:203)
	at org.gradle.tooling.internal.consumer.connection.CancellableModelBuilderBackedModelProducer.produceModel(CancellableModelBuilderBackedModelProducer.java:54)
	at org.gradle.tooling.internal.consumer.connection.PluginClasspathInjectionSupportedCheckModelProducer.produceModel(PluginClasspathInjectionSupportedCheckModelProducer.java:38)
	at org.gradle.tooling.internal.consumer.connection.AbstractConsumerConnection.run(AbstractConsumerConnection.java:62)
	at org.gradle.tooling.internal.consumer.connection.ParameterValidatingConsumerConnection.run(ParameterValidatingConsumerConnection.java:47)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:97)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:89)
	at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.run(LazyConsumerActionExecutor.java:87)
	at org.gradle.tooling.internal.consumer.connection.CancellableConsumerActionExecutor.run(CancellableConsumerActionExecutor.java:45)
	at org.gradle.tooling.internal.consumer.connection.ProgressLoggingConsumerActionExecutor.run(ProgressLoggingConsumerActionExecutor.java:61)
	at org.gradle.tooling.internal.consumer.connection.RethrowingErrorsConsumerActionExecutor.run(RethrowingErrorsConsumerActionExecutor.java:38)
	at org.gradle.tooling.internal.consumer.async.DefaultAsyncConsumerActionExecutor$1$1.run(DefaultAsyncConsumerActionExecutor.java:60)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
Caused by: org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':one:revapiAnalyze'.
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:68)
	at org.gradle.execution.plan.TaskDependencyResolver.resolveDependenciesFor(TaskDependencyResolver.java:46)
	at org.gradle.execution.plan.LocalTaskNode.getDependencies(LocalTaskNode.java:106)
	at org.gradle.execution.plan.LocalTaskNode.resolveDependencies(LocalTaskNode.java:79)
	at org.gradle.execution.plan.DefaultExecutionPlan.addEntryTasks(DefaultExecutionPlan.java:176)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.addEntryTasks(DefaultTaskExecutionGraph.java:139)
	at org.gradle.execution.TaskNameResolvingBuildConfigurationAction.configure(TaskNameResolvingBuildConfigurationAction.java:49)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$2.proceed(DefaultBuildConfigurationActionExecuter.java:66)
	at org.gradle.execution.DefaultTasksBuildExecutionAction.configure(DefaultTasksBuildExecutionAction.java:45)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$2.proceed(DefaultBuildConfigurationActionExecuter.java:66)
	at org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction.configure(ExcludedTaskFilteringBuildConfigurationAction.java:48)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$1.run(DefaultBuildConfigurationActionExecuter.java:44)
	at org.gradle.internal.Factories$1.create(Factories.java:26)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry.withLenientState(DefaultProjectStateRegistry.java:133)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry.withLenientState(DefaultProjectStateRegistry.java:125)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.select(DefaultBuildConfigurationActionExecuter.java:40)
	at org.gradle.initialization.DefaultTaskExecutionPreparer.prepareForTaskExecution(DefaultTaskExecutionPreparer.java:38)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer$CalculateTaskGraph.populateTaskGraph(BuildOperatingFiringTaskExecutionPreparer.java:82)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer$CalculateTaskGraph.run(BuildOperatingFiringTaskExecutionPreparer.java:57)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:92)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer.prepareForTaskExecution(BuildOperatingFiringTaskExecutionPreparer.java:45)
	at org.gradle.initialization.DefaultGradleLauncher.prepareTaskExecution(DefaultGradleLauncher.java:206)
	at org.gradle.initialization.DefaultGradleLauncher.doClassicBuildStages(DefaultGradleLauncher.java:142)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:126)
	... 74 more
Caused by: org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':one:revapiOldApi_0.1.0_transitive'.
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.wrapException(ErrorHandlingConfigurationResolver.java:104)
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.resolveGraph(ErrorHandlingConfigurationResolver.java:76)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$7.run(DefaultConfiguration.java:612)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:92)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveGraphIfRequired(DefaultConfiguration.java:603)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.access$600(DefaultConfiguration.java:139)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$6.run(DefaultConfiguration.java:583)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry$SafeExclusiveLockImpl.withLock(DefaultProjectStateRegistry.java:245)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveExclusively(DefaultConfiguration.java:579)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveToStateOrLater(DefaultConfiguration.java:574)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.access$2300(DefaultConfiguration.java:139)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies.assertArtifactsResolved(DefaultConfiguration.java:1489)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies.access$3500(DefaultConfiguration.java:1367)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies$LenientResolutionResult.resolve(DefaultConfiguration.java:1504)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies$LenientResolutionResult.getAllDependencies(DefaultConfiguration.java:1523)
	at com.palantir.gradle.revapi.OldApiConfigurations.resolveConfigurationUnlessMissingJars(OldApiConfigurations.java:57)
	at com.palantir.gradle.revapi.OldApiConfigurations.lambda$resolveOldConfiguration$1(OldApiConfigurations.java:50)
	at com.palantir.gradle.revapi.PreviousVersionResolutionHelpers.withRenamedGroupForCurrentThread(PreviousVersionResolutionHelpers.java:73)
	at com.palantir.gradle.revapi.OldApiConfigurations.resolveOldConfiguration(OldApiConfigurations.java:49)
	at com.palantir.gradle.revapi.ResolveOldApi.resolveOldApiWithVersion(ResolveOldApi.java:102)
	at com.palantir.gradle.revapi.ResolveOldApi.resolveOldApiAcrossAllOldVersions(ResolveOldApi.java:69)
	at com.palantir.gradle.revapi.ResolveOldApi.lambda$oldApiProvider$0(ResolveOldApi.java:48)
	at com.palantir.gradle.revapi.GradleUtils$MemoizingSupplier.get(GradleUtils.java:49)
	at org.gradle.api.internal.provider.DefaultProvider.getOrNull(DefaultProvider.java:41)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.isPresent(AbstractMinimalProvider.java:43)
	at org.gradle.api.internal.provider.AbstractMappingProvider.isPresent(AbstractMappingProvider.java:40)
	at org.gradle.api.internal.provider.AbstractMappingProvider.isPresent(AbstractMappingProvider.java:40)
	at org.gradle.api.internal.provider.DefaultProperty.isPresent(DefaultProperty.java:179)
	at org.gradle.api.internal.tasks.properties.bean.AbstractNestedRuntimeBeanNode$BeanPropertyValue.call(AbstractNestedRuntimeBeanNode.java:152)
	at org.gradle.util.GUtil.uncheckedCall(GUtil.java:461)
	at org.gradle.util.DeferredUtil.unpackNestableDeferred(DeferredUtil.java:64)
	at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:74)
	at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:84)
	at org.gradle.api.internal.file.DefaultFileCollectionFactory$ResolvingFileCollection.visitContents(DefaultFileCollectionFactory.java:210)
	at org.gradle.api.internal.file.CompositeFileCollection.visitDependencies(CompositeFileCollection.java:186)
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext$TaskGraphImpl.getNodeValues(CachingTaskDependencyResolveContext.java:111)
	at org.gradle.internal.graph.CachingDirectedGraphWalker$GraphWithEmptyEdges.getNodeValues(CachingDirectedGraphWalker.java:213)
	at org.gradle.internal.graph.CachingDirectedGraphWalker.doSearch(CachingDirectedGraphWalker.java:121)
	at org.gradle.internal.graph.CachingDirectedGraphWalker.findValues(CachingDirectedGraphWalker.java:73)
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:66)
	... 109 more
Caused by: org.gradle.api.InvalidUserDataException: Cannot change dependencies of configuration ':gcvVersionsPropsConstraints' after it has been included in dependency resolution.
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.preventIllegalMutation(DefaultConfiguration.java:1136)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.validateMutation(DefaultConfiguration.java:1098)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.extendsFrom(DefaultConfiguration.java:372)
	at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$setupConfiguration$13(VersionsPropsPlugin.java:201)
	at org.gradle.internal.ImmutableActionSet$SingletonSet.execute(ImmutableActionSet.java:225)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.runDependencyActions(DefaultConfiguration.java:463)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.realizeDependencies(DefaultLocalComponentMetadata.java:511)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.addDefinedExcludes(DefaultLocalComponentMetadata.java:469)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.getExcludes(DefaultLocalComponentMetadata.java:460)
	at org.gradle.internal.component.model.DefaultSelectedByVariantMatchingConfigurationMetadata.getExcludes(DefaultSelectedByVariantMatchingConfigurationMetadata.java:73)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.computeNodeExclusions(NodeState.java:613)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.computeModuleResolutionFilter(NodeState.java:603)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.visitOutgoingDependencies(NodeState.java:250)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.traverseGraph(DependencyGraphBuilder.java:180)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.resolve(DependencyGraphBuilder.java:142)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver.resolve(DefaultArtifactDependencyResolver.java:123)
	at org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver.resolveGraph(DefaultConfigurationResolver.java:175)
	at org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurationResolver.resolveGraph(ShortCircuitEmptyConfigurationResolver.java:86)
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.resolveGraph(ErrorHandlingConfigurationResolver.java:74)
	... 153 more


	at com.palantir.gradle.revapi.RevapiSpec.revapi task is compatible with gradle-consistent-versions(RevapiSpec.groovy:1223)
Caused by: org.gradle.api.GradleException: Build aborted because of an internal error.
	at nebula.test.functional.internal.DefaultExecutionResult.rethrowFailure(DefaultExecutionResult.groovy:97)
	at com.palantir.gradle.revapi.RevapiSpec.runTasksSuccessfully(RevapiSpec.groovy:1317)
	... 1 more
Caused by: org.gradle.internal.exceptions.LocationAwareException: Could not determine the dependencies of task ':one:revapiAnalyze'.
	at org.gradle.initialization.exception.DefaultExceptionAnalyser.transform(DefaultExceptionAnalyser.java:99)
	at org.gradle.initialization.exception.DefaultExceptionAnalyser.collectFailures(DefaultExceptionAnalyser.java:65)
	at org.gradle.initialization.exception.MultipleBuildFailuresExceptionAnalyser.transform(MultipleBuildFailuresExceptionAnalyser.java:48)
	at org.gradle.initialization.exception.StackTraceSanitizingExceptionAnalyser.transform(StackTraceSanitizingExceptionAnalyser.java:30)
	at org.gradle.initialization.DefaultGradleLauncher.finishBuild(DefaultGradleLauncher.java:162)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:129)
	at org.gradle.initialization.DefaultGradleLauncher.executeTasks(DefaultGradleLauncher.java:106)
	at org.gradle.internal.invocation.GradleBuildController$1.execute(GradleBuildController.java:60)
	at org.gradle.internal.invocation.GradleBuildController$1.execute(GradleBuildController.java:57)
	at org.gradle.internal.invocation.GradleBuildController$3.create(GradleBuildController.java:85)
	at org.gradle.internal.invocation.GradleBuildController$3.create(GradleBuildController.java:78)
	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:189)
	at org.gradle.internal.work.StopShieldingWorkerLeaseService.withLocks(StopShieldingWorkerLeaseService.java:40)
	at org.gradle.internal.invocation.GradleBuildController.doBuild(GradleBuildController.java:78)
	at org.gradle.internal.invocation.GradleBuildController.run(GradleBuildController.java:57)
	at org.gradle.tooling.internal.provider.runner.BuildModelActionRunner.run(BuildModelActionRunner.java:54)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner.run(BuildOutcomeReportingBuildActionRunner.java:63)
	at org.gradle.tooling.internal.provider.ValidatingBuildActionRunner.run(ValidatingBuildActionRunner.java:32)
	at org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner.run(BuildCompletionNotifyingBuildActionRunner.java:39)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner$3.call(RunAsBuildOperationBuildActionRunner.java:51)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner$3.call(RunAsBuildOperationBuildActionRunner.java:45)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:416)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$CallableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:406)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:102)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.call(DelegatingBuildOperationExecutor.java:36)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionRunner.run(RunAsBuildOperationBuildActionRunner.java:45)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter$1.transform(InProcessBuildActionExecuter.java:50)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter$1.transform(InProcessBuildActionExecuter.java:47)
	at org.gradle.composite.internal.DefaultRootBuildState.run(DefaultRootBuildState.java:78)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:47)
	at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:31)
	at org.gradle.launcher.exec.BuildTreeScopeBuildActionExecuter.execute(BuildTreeScopeBuildActionExecuter.java:42)
	at org.gradle.launcher.exec.BuildTreeScopeBuildActionExecuter.execute(BuildTreeScopeBuildActionExecuter.java:28)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:78)
	at org.gradle.tooling.internal.provider.ContinuousBuildActionExecuter.execute(ContinuousBuildActionExecuter.java:52)
	at org.gradle.tooling.internal.provider.SubscribableBuildActionExecuter.execute(SubscribableBuildActionExecuter.java:59)
	at org.gradle.tooling.internal.provider.SubscribableBuildActionExecuter.execute(SubscribableBuildActionExecuter.java:36)
	at org.gradle.tooling.internal.provider.SessionScopeBuildActionExecuter.execute(SessionScopeBuildActionExecuter.java:68)
	at org.gradle.tooling.internal.provider.SessionScopeBuildActionExecuter.execute(SessionScopeBuildActionExecuter.java:38)
	at org.gradle.tooling.internal.provider.GradleThreadBuildActionExecuter.execute(GradleThreadBuildActionExecuter.java:37)
	at org.gradle.tooling.internal.provider.GradleThreadBuildActionExecuter.execute(GradleThreadBuildActionExecuter.java:26)
	at org.gradle.tooling.internal.provider.ParallelismConfigurationBuildActionExecuter.execute(ParallelismConfigurationBuildActionExecuter.java:43)
	at org.gradle.tooling.internal.provider.ParallelismConfigurationBuildActionExecuter.execute(ParallelismConfigurationBuildActionExecuter.java:29)
	at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:60)
	at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:32)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:55)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:41)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:48)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:32)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter$1.create(StdInSwapExecuter.java:44)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter$1.create(StdInSwapExecuter.java:41)
	at org.gradle.util.Swapper.swap(Swapper.java:38)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter.execute(StdInSwapExecuter.java:41)
	at org.gradle.tooling.internal.provider.StdInSwapExecuter.execute(StdInSwapExecuter.java:30)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:51)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:35)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:60)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:38)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:193)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:136)
	at org.gradle.tooling.internal.provider.DefaultConnection.getModel(DefaultConnection.java:203)
	at org.gradle.tooling.internal.consumer.connection.CancellableModelBuilderBackedModelProducer.produceModel(CancellableModelBuilderBackedModelProducer.java:54)
	at org.gradle.tooling.internal.consumer.connection.PluginClasspathInjectionSupportedCheckModelProducer.produceModel(PluginClasspathInjectionSupportedCheckModelProducer.java:38)
	at org.gradle.tooling.internal.consumer.connection.AbstractConsumerConnection.run(AbstractConsumerConnection.java:62)
	at org.gradle.tooling.internal.consumer.connection.ParameterValidatingConsumerConnection.run(ParameterValidatingConsumerConnection.java:47)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:97)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:89)
	at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.run(LazyConsumerActionExecutor.java:87)
	at org.gradle.tooling.internal.consumer.connection.CancellableConsumerActionExecutor.run(CancellableConsumerActionExecutor.java:45)
	at org.gradle.tooling.internal.consumer.connection.ProgressLoggingConsumerActionExecutor.run(ProgressLoggingConsumerActionExecutor.java:61)
	at org.gradle.tooling.internal.consumer.connection.RethrowingErrorsConsumerActionExecutor.run(RethrowingErrorsConsumerActionExecutor.java:38)
	at org.gradle.tooling.internal.consumer.async.DefaultAsyncConsumerActionExecutor$1$1.run(DefaultAsyncConsumerActionExecutor.java:60)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
Caused by: org.gradle.api.internal.tasks.TaskDependencyResolveException: Could not determine the dependencies of task ':one:revapiAnalyze'.
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:68)
	at org.gradle.execution.plan.TaskDependencyResolver.resolveDependenciesFor(TaskDependencyResolver.java:46)
	at org.gradle.execution.plan.LocalTaskNode.getDependencies(LocalTaskNode.java:106)
	at org.gradle.execution.plan.LocalTaskNode.resolveDependencies(LocalTaskNode.java:79)
	at org.gradle.execution.plan.DefaultExecutionPlan.addEntryTasks(DefaultExecutionPlan.java:176)
	at org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.addEntryTasks(DefaultTaskExecutionGraph.java:139)
	at org.gradle.execution.TaskNameResolvingBuildConfigurationAction.configure(TaskNameResolvingBuildConfigurationAction.java:49)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$2.proceed(DefaultBuildConfigurationActionExecuter.java:66)
	at org.gradle.execution.DefaultTasksBuildExecutionAction.configure(DefaultTasksBuildExecutionAction.java:45)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$2.proceed(DefaultBuildConfigurationActionExecuter.java:66)
	at org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction.configure(ExcludedTaskFilteringBuildConfigurationAction.java:48)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.configure(DefaultBuildConfigurationActionExecuter.java:58)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.access$200(DefaultBuildConfigurationActionExecuter.java:26)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter$1.run(DefaultBuildConfigurationActionExecuter.java:44)
	at org.gradle.internal.Factories$1.create(Factories.java:26)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry.withLenientState(DefaultProjectStateRegistry.java:133)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry.withLenientState(DefaultProjectStateRegistry.java:125)
	at org.gradle.execution.DefaultBuildConfigurationActionExecuter.select(DefaultBuildConfigurationActionExecuter.java:40)
	at org.gradle.initialization.DefaultTaskExecutionPreparer.prepareForTaskExecution(DefaultTaskExecutionPreparer.java:38)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer$CalculateTaskGraph.populateTaskGraph(BuildOperatingFiringTaskExecutionPreparer.java:82)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer$CalculateTaskGraph.run(BuildOperatingFiringTaskExecutionPreparer.java:57)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:92)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
	at org.gradle.initialization.BuildOperatingFiringTaskExecutionPreparer.prepareForTaskExecution(BuildOperatingFiringTaskExecutionPreparer.java:45)
	at org.gradle.initialization.DefaultGradleLauncher.prepareTaskExecution(DefaultGradleLauncher.java:206)
	at org.gradle.initialization.DefaultGradleLauncher.doClassicBuildStages(DefaultGradleLauncher.java:142)
	at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:126)
	... 74 more
Caused by: org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':one:revapiOldApi_0.1.0_transitive'.
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.wrapException(ErrorHandlingConfigurationResolver.java:104)
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.resolveGraph(ErrorHandlingConfigurationResolver.java:76)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$7.run(DefaultConfiguration.java:612)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:402)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$RunnableBuildOperationWorker.execute(DefaultBuildOperationExecutor.java:394)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$1.execute(DefaultBuildOperationExecutor.java:165)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:250)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.execute(DefaultBuildOperationExecutor.java:158)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:92)
	at org.gradle.internal.operations.DelegatingBuildOperationExecutor.run(DelegatingBuildOperationExecutor.java:31)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveGraphIfRequired(DefaultConfiguration.java:603)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.access$600(DefaultConfiguration.java:139)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$6.run(DefaultConfiguration.java:583)
	at org.gradle.api.internal.project.DefaultProjectStateRegistry$SafeExclusiveLockImpl.withLock(DefaultProjectStateRegistry.java:245)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveExclusively(DefaultConfiguration.java:579)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.resolveToStateOrLater(DefaultConfiguration.java:574)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.access$2300(DefaultConfiguration.java:139)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies.assertArtifactsResolved(DefaultConfiguration.java:1489)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies.access$3500(DefaultConfiguration.java:1367)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies$LenientResolutionResult.resolve(DefaultConfiguration.java:1504)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$ConfigurationResolvableDependencies$LenientResolutionResult.getAllDependencies(DefaultConfiguration.java:1523)
	at com.palantir.gradle.revapi.OldApiConfigurations.resolveConfigurationUnlessMissingJars(OldApiConfigurations.java:57)
	at com.palantir.gradle.revapi.OldApiConfigurations.lambda$resolveOldConfiguration$1(OldApiConfigurations.java:50)
	at com.palantir.gradle.revapi.PreviousVersionResolutionHelpers.withRenamedGroupForCurrentThread(PreviousVersionResolutionHelpers.java:73)
	at com.palantir.gradle.revapi.OldApiConfigurations.resolveOldConfiguration(OldApiConfigurations.java:49)
	at com.palantir.gradle.revapi.ResolveOldApi.resolveOldApiWithVersion(ResolveOldApi.java:102)
	at com.palantir.gradle.revapi.ResolveOldApi.resolveOldApiAcrossAllOldVersions(ResolveOldApi.java:69)
	at com.palantir.gradle.revapi.ResolveOldApi.lambda$oldApiProvider$0(ResolveOldApi.java:48)
	at com.palantir.gradle.revapi.GradleUtils$MemoizingSupplier.get(GradleUtils.java:49)
	at org.gradle.api.internal.provider.DefaultProvider.getOrNull(DefaultProvider.java:41)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.isPresent(AbstractMinimalProvider.java:43)
	at org.gradle.api.internal.provider.AbstractMappingProvider.isPresent(AbstractMappingProvider.java:40)
	at org.gradle.api.internal.provider.AbstractMappingProvider.isPresent(AbstractMappingProvider.java:40)
	at org.gradle.api.internal.provider.DefaultProperty.isPresent(DefaultProperty.java:179)
	at org.gradle.api.internal.tasks.properties.bean.AbstractNestedRuntimeBeanNode$BeanPropertyValue.call(AbstractNestedRuntimeBeanNode.java:152)
	at org.gradle.util.GUtil.uncheckedCall(GUtil.java:461)
	at org.gradle.util.DeferredUtil.unpackNestableDeferred(DeferredUtil.java:64)
	at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:74)
	at org.gradle.api.internal.file.collections.UnpackingVisitor.add(UnpackingVisitor.java:84)
	at org.gradle.api.internal.file.DefaultFileCollectionFactory$ResolvingFileCollection.visitContents(DefaultFileCollectionFactory.java:210)
	at org.gradle.api.internal.file.CompositeFileCollection.visitDependencies(CompositeFileCollection.java:186)
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext$TaskGraphImpl.getNodeValues(CachingTaskDependencyResolveContext.java:111)
	at org.gradle.internal.graph.CachingDirectedGraphWalker$GraphWithEmptyEdges.getNodeValues(CachingDirectedGraphWalker.java:213)
	at org.gradle.internal.graph.CachingDirectedGraphWalker.doSearch(CachingDirectedGraphWalker.java:121)
	at org.gradle.internal.graph.CachingDirectedGraphWalker.findValues(CachingDirectedGraphWalker.java:73)
	at org.gradle.api.internal.tasks.CachingTaskDependencyResolveContext.getDependencies(CachingTaskDependencyResolveContext.java:66)
	... 109 more
Caused by: org.gradle.api.InvalidUserDataException: Cannot change dependencies of configuration ':gcvVersionsPropsConstraints' after it has been included in dependency resolution.
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.preventIllegalMutation(DefaultConfiguration.java:1136)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.validateMutation(DefaultConfiguration.java:1098)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.extendsFrom(DefaultConfiguration.java:372)
	at com.palantir.gradle.versions.VersionsPropsPlugin.lambda$setupConfiguration$13(VersionsPropsPlugin.java:201)
	at org.gradle.internal.ImmutableActionSet$SingletonSet.execute(ImmutableActionSet.java:225)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.runDependencyActions(DefaultConfiguration.java:463)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.realizeDependencies(DefaultLocalComponentMetadata.java:511)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.addDefinedExcludes(DefaultLocalComponentMetadata.java:469)
	at org.gradle.internal.component.local.model.DefaultLocalComponentMetadata$DefaultLocalConfigurationMetadata.getExcludes(DefaultLocalComponentMetadata.java:460)
	at org.gradle.internal.component.model.DefaultSelectedByVariantMatchingConfigurationMetadata.getExcludes(DefaultSelectedByVariantMatchingConfigurationMetadata.java:73)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.computeNodeExclusions(NodeState.java:613)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.computeModuleResolutionFilter(NodeState.java:603)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState.visitOutgoingDependencies(NodeState.java:250)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.traverseGraph(DependencyGraphBuilder.java:180)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DependencyGraphBuilder.resolve(DependencyGraphBuilder.java:142)
	at org.gradle.api.internal.artifacts.ivyservice.resolveengine.DefaultArtifactDependencyResolver.resolve(DefaultArtifactDependencyResolver.java:123)
	at org.gradle.api.internal.artifacts.ivyservice.DefaultConfigurationResolver.resolveGraph(DefaultConfigurationResolver.java:175)
	at org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurationResolver.resolveGraph(ShortCircuitEmptyConfigurationResolver.java:86)
	at org.gradle.api.internal.artifacts.ivyservice.ErrorHandlingConfigurationResolver.resolveGraph(ErrorHandlingConfigurationResolver.java:74)
	... 153 more

```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Test-only: Fix is still required.
==COMMIT_MSG==

## Possible downsides?
This change just contains the test demonstrating the problem, not a fix.

