### PR TITLE
Grab outgoing configuration artifacts instead of jar task output

### DIFF
--- a/changelog/@unreleased/pr-341.v2.yml
+++ b/changelog/@unreleased/pr-341.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: revapi should now work seamlessly in projects that also apply `com.palantir.shadow-jar`
+  links:
+  - https://github.com/palantir/gradle-revapi/pull/341

--- a/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiPlugin.java
@@ -79,10 +79,12 @@ public final class RevapiPlugin implements Plugin<Project> {
 
                     task.getAcceptedBreaks().set(acceptedBreaks(project, configManager, extension.oldGroupAndName()));
 
-                    FileCollection thisJarFile = project.getTasks()
-                            .withType(Jar.class)
-                            .getByName(JavaPlugin.JAR_TASK_NAME)
-                            .getOutputs()
+                    // we don't want to just grab the output of the 'jar' task, because peiple using
+                    // 'com.palantir.shadow-jar' actually publish the output of a different task: 'shadowJar'
+                    FileCollection thisJarFile = project.getConfigurations()
+                            .getByName(JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+                            .getOutgoing()
+                            .getArtifacts()
                             .getFiles();
 
                     FileCollection otherProjectsOutputs = revapiNewApiElements


### PR DESCRIPTION
## Before this PR

In the internal atlas proxy repo that @jeremyk-91 and @Jolyon-S work on, they've made a recent change where a project has both `com.palantir.revapi` and also `com.palantir.shadow-jar`.  This leads to spurious revapi failures (and is quickly filling up the 'accepted breaks' file) because it's comparing the `-thin` jar against the 'fat' jar that was published previously. 

e.g.

```
old: class com.palantir.a.client.MigrationKeyValueTransaction
new: class com.palantir.a.client.MigrationKeyValueTransaction

SOURCE: BREAKING, BINARY: BREAKING

From old archive: a-client-java-1.71.0.jar
From new archive: a-client-java-1.71.0-1-gc3de524-thin.jar
```
https://circle/gh/foundry/a-client-java/28615

## After this PR
==COMMIT_MSG==
revapi should now work seamlessly in projects that also apply `com.palantir.shadow-jar`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

