### PR TITLE
Update git stderr message when no tags returned, fixes #322

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -50,7 +50,8 @@ final class GitVersionUtils {
 
         GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
-        if (describeResult.stderr().contains("No tags can describe") || describeResult.stderr().contains("No names found, cannot describe anything")) {
+        if (describeResult.stderr().contains("No tags can describe") 
+            || describeResult.stderr().contains("No names found, cannot describe anything")) {
             return Optional.empty();
         }
 

--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -51,7 +51,7 @@ final class GitVersionUtils {
         GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
         if (describeResult.stderr().contains("No tags can describe")
-            || describeResult.stderr().contains("No names found, cannot describe anything")) {
+                || describeResult.stderr().contains("No names found, cannot describe anything")) {
             return Optional.empty();
         }
 

--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -50,7 +50,7 @@ final class GitVersionUtils {
 
         GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
-        if (describeResult.stderr().contains("No tags can describe")) {
+        if (describeResult.stderr().contains("No tags can describe") || describeResult.stderr().contains("No names found, cannot describe anything")) {
             return Optional.empty();
         }
 

--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -50,7 +50,7 @@ final class GitVersionUtils {
 
         GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
-        if (describeResult.stderr().contains("No tags can describe") 
+        if (describeResult.stderr().contains("No tags can describe")
             || describeResult.stderr().contains("No names found, cannot describe anything")) {
             return Optional.empty();
         }


### PR DESCRIPTION
## Before this PR
This `git` error message that gets output to `stderr` when there are no git tags results in an exception and a failed build.

**Example output currently**
```
   > Failed to query the value of extension 'revapi' property 'oldVersions'.
      > Failed running command:
                Command:[]
                Exit code: 128
                Stdout:
                Stderr:fatal: No names found, cannot describe anything.

```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
No version will be returned if git tags are empty, `Optional.empty`, instead of an exception being thrown.
Fixes #322 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
There shouldn't be any since this is a "non-breaking" change.  If a previous version of `git` has old error message this still works.
