### PR TITLE
Not by way of matching git error messages

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitVersionUtils.java
@@ -50,9 +50,13 @@ final class GitVersionUtils {
 
         GitResult describeResult = execute(project, "git", "describe", "--tags", "--abbrev=0", beforeLastRef);
 
-        if (describeResult.stderr().contains("No tags can describe")
-                || describeResult.stderr().contains("No names found, cannot describe anything")) {
-            return Optional.empty();
+        if (describeResult.exitCode() != 0) {
+            GitResult alwaysDescribeResult =
+                    execute(project, "git", "describe", "--always", "--tags", "--abbrev=0", beforeLastRef);
+            if (alwaysDescribeResult.exitCode() == 0) {
+                // 'No tags can describe' or 'No names found, cannot describe anything'
+                return Optional.empty();
+            }
         }
 
         return Optional.of(describeResult.stdoutOrThrowIfNonZero());


### PR DESCRIPTION
## Before this PR

The error message output text is different for different language settings and different distributions of git. So maybe we shouldn't use git's error output in logic.

Related issues: https://github.com/palantir/gradle-revapi/issues/550

https://github.com/git/git/tree/master/po#contributing-to-an-existing-translation

## After this PR

This code works as expected in every language configuration and git distribution

## Possible downsides?

The behavior before and after the PR is consistent for existing versions of git. But this seems to depend on git's internal implementation, don't know if there is a better way.
