### PR TITLE
Ref #612: Use detachedConfiguration() to cleanly resolve old API artifact with Gradle 8.2+

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/OldApiConfigurations.java
+++ b/src/main/java/com/palantir/gradle/revapi/OldApiConfigurations.java
@@ -36,14 +36,8 @@ final class OldApiConfigurations {
 
         Dependency oldApiDependency = project.getDependencies().create(groupNameVersion.asString());
 
-        String transitivityString = transitive ? "_transitive" : "";
-        String configurationName = "revapiOldApi_" + groupNameVersion.version().asString() + transitivityString;
-
-        Configuration oldApiConfiguration = project.getConfigurations().create(configurationName, conf -> {
-            conf.getDependencies().add(oldApiDependency);
-            conf.setCanBeConsumed(false);
-            conf.setVisible(false);
-        });
+        Configuration oldApiConfiguration = project.getConfigurations().detachedConfiguration();
+        oldApiConfiguration.getDependencies().add(oldApiDependency);
         oldApiConfiguration.setTransitive(transitive);
 
         return PreviousVersionResolutionHelpers.withRenamedGroupForCurrentThread(


### PR DESCRIPTION
## Before this PR
With Gradle 8.2+, revapi plugin doesn't detect any ABI/API breaks.
The reason is because it doesn't resolve the right artifacts for the old API: it always compares new API with new API.
The old API artifact is actually resolved using the project version (so the SNAPSHOT version) instead of the old version defined.

## After this PR
Using `detachedConfiguration()` in the `OldApiConfigurations` allow to not get the project default artifact but actually the old API one (correct).

## Possible downsides?
This change works with any Gradle version. The only downside with `detachedConfiguration()` is when using `--configuration-cache` as detached configurations can't be cached.

This closes #612 

