### PR TITLE
fix can fail to report ABI breaks when using Gradle 8.2+

### DIFF
--- a/src/main/java/com/palantir/gradle/revapi/OldApiConfigurations.java
+++ b/src/main/java/com/palantir/gradle/revapi/OldApiConfigurations.java
@@ -36,15 +36,8 @@ final class OldApiConfigurations {
 
         Dependency oldApiDependency = project.getDependencies().create(groupNameVersion.asString());
 
-        String transitivityString = transitive ? "_transitive" : "";
-        String configurationName = "revapiOldApi_" + groupNameVersion.version().asString() + transitivityString;
-
-        @SuppressWarnings("for-rollout:ConfigurationAvoidanceRegistration")
-        Configuration oldApiConfiguration = project.getConfigurations().create(configurationName, conf -> {
-            conf.getDependencies().add(oldApiDependency);
-            conf.setCanBeConsumed(false);
-            conf.setVisible(false);
-        });
+        Configuration oldApiConfiguration = project.getConfigurations().detachedConfiguration();
+        oldApiConfiguration.getDependencies().add(oldApiDependency);
         oldApiConfiguration.setTransitive(transitive);
 
         return PreviousVersionResolutionHelpers.withRenamedGroupForCurrentThread(


### PR DESCRIPTION
The `com.palantir.revapi` plugin has a pretty nasty bug where `revapi` can fail to report ABI breaks when using Gradle 8.2+. This was [fixed](https://github.com/revapi/gradle-revapi/pull/4) in the new `org.revapi.revapi-gradle-plugin` fork. As we are unforking we want to port over this fix to `com.palantir.revapi`

