### PR TITLE
Remove warning from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 <a href="https://autorelease.general.dmz.palantir.tech/palantir/gradle-revapi"><img src="https://img.shields.io/badge/Perform%20an-Autorelease-success.svg" alt="Autorelease"></a>
 </p>
 
-# WARNING: This repo is no longer maintained.
-Use the fork established by the [Revapi](https://github.com/revapi/gradle-revapi) owners.
-
 # gradle-revapi
 
 _A gradle plugin which runs [Revapi](https://revapi.org) to warn you when there are breaks to your Java library's


### PR DESCRIPTION
## Before this PR

the README contains a warning message

## After this PR

the README does not contain a warning message

## Motivation

version 2.0 was released today

<img width="237" height="133" alt="image" src="https://github.com/user-attachments/assets/7ef74fc8-e124-4c7d-bb6e-c77c42a5f3b4" />
