### PR TITLE
Add old version pattern filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,25 @@ to need to override the artifact to compare against, you can do so:
 ```gradle
 revapi {
     oldGroup = '<artifact-group>'
-    oldNamed = '<artifact-name>'
+    oldName = '<artifact-name>'
     oldVersion = '<artifact-version>'
 }
 ```
+
+### Ignoring prerelease versions
+
+By default, the plugin considers every previous Git tag when selecting the old version. To ignore prerelease tags such
+as alpha, beta, or release candidate builds, configure `oldVersionPattern` with a regular expression that stable
+versions match:
+
+```gradle
+revapi {
+    oldVersionPattern = '[0-9]+[.][0-9]+[.][0-9]+'
+}
+```
+
+The pattern is matched against the entire version after a leading `v` has been removed from Git tags. It also applies
+to versions configured explicitly through `oldVersion` or `oldVersions`.
 
 ### Accepting breaks
 

--- a/src/main/java/com/palantir/gradle/revapi/GitOperations.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitOperations.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.revapi;
 import com.palantir.gradle.gitversion.GitInvoker;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Nested;
@@ -33,8 +34,9 @@ import org.gradle.api.tasks.Nested;
  *   <li>Run {@code git describe --tags --abbrev=0} to find the nearest reachable tag from that commit.
  *   <li>If the tag is the sentinel {@code 0.0.0}, only accept it when the commit has a parent (filters out the
  *       synthetic root-commit tag used when no real releases exist yet).
- *   <li>Feed that tag back in as the next ref and repeat, collecting up to {@link #TAGS_TO_RETURN} tags.
- *   <li>Strip a leading {@code v} from each tag before returning.
+ *   <li>Feed that tag back in as the next ref and repeat.
+ *   <li>Strip a leading {@code v}, filter the tags using the configured version pattern, and return up to
+ *       {@link #TAGS_TO_RETURN} matches.
  * </ol>
  */
 public abstract class GitOperations {
@@ -45,13 +47,22 @@ public abstract class GitOperations {
     protected abstract GitInvoker getGitInvoker();
 
     public final Provider<List<String>> previousGitTags() {
+        return previousGitTags(Pattern.compile(".*"));
+    }
+
+    final Provider<List<String>> previousGitTags(Provider<String> versionPattern) {
+        return versionPattern.flatMap(patternString -> previousGitTags(Pattern.compile(patternString)));
+    }
+
+    private Provider<List<String>> previousGitTags(Pattern versionPattern) {
         return previousGitTagFromRef("HEAD")
                 .map(seed -> Stream.iterate(
                                 seed,
                                 Objects::nonNull,
                                 ref -> previousGitTagFromRef(ref).getOrNull())
-                        .limit(TAGS_TO_RETURN)
                         .map(GitOperations::stripVFromTag)
+                        .filter(tag -> versionPattern.matcher(tag).matches())
+                        .limit(TAGS_TO_RETURN)
                         .toList())
                 .orElse(List.of());
     }

--- a/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
+++ b/src/main/java/com/palantir/gradle/revapi/ResolveOldApi.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
@@ -52,7 +53,11 @@ final class ResolveOldApi {
     private static Optional<OldApi> resolveOldApiAcrossAllOldVersions(
             Project project, RevapiExtension extension, GradleRevapiConfig config) {
 
-        List<String> oldVersionStrings = extension.getOldVersions().get();
+        Pattern oldVersionPattern =
+                Pattern.compile(extension.getOldVersionPattern().get());
+        List<String> oldVersionStrings = extension.getOldVersions().get().stream()
+                .filter(version -> oldVersionPattern.matcher(version).matches())
+                .toList();
 
         if (oldVersionStrings.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/com/palantir/gradle/revapi/RevapiExtension.java
+++ b/src/main/java/com/palantir/gradle/revapi/RevapiExtension.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Nested;
 public abstract class RevapiExtension {
     private final Property<String> oldGroup;
     private final Property<String> oldName;
+    private final Property<String> oldVersionPattern;
     private final ListProperty<String> oldVersions;
     private final Provider<GroupAndName> oldGroupAndName;
 
@@ -41,8 +42,10 @@ public abstract class RevapiExtension {
         this.oldName = project.getObjects().property(String.class);
         this.oldName.set(project.getProviders().provider(project::getName));
 
+        this.oldVersionPattern = project.getObjects().property(String.class).convention(".*");
+
         this.oldVersions = project.getObjects().listProperty(String.class);
-        this.oldVersions.set(getGitOperations().previousGitTags());
+        this.oldVersions.set(getGitOperations().previousGitTags(oldVersionPattern));
 
         this.oldGroupAndName = project.provider(() ->
                 GroupAndName.builder().group(oldGroup.get()).name(oldName.get()).build());
@@ -57,6 +60,14 @@ public abstract class RevapiExtension {
 
     public Property<String> getOldName() {
         return oldName;
+    }
+
+    /**
+     * A regular expression which candidate old versions must match. This can be used to exclude prerelease versions
+     * such as alpha, beta, and release candidate builds. Defaults to matching every version.
+     */
+    public Property<String> getOldVersionPattern() {
+        return oldVersionPattern;
     }
 
     public ListProperty<String> getOldVersions() {

--- a/src/test/java/com/palantir/gradle/revapi/GitOperationsTest.java
+++ b/src/test/java/com/palantir/gradle/revapi/GitOperationsTest.java
@@ -86,6 +86,27 @@ class GitOperationsTest {
     }
 
     @Test
+    void filters_tags_before_limiting_the_number_returned(GradleInvoker gradle, Git git, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            revapi {
+                oldVersionPattern = '[0-9]+[.][0-9]+[.][0-9]+'
+            }
+            """);
+
+        git.commit("First");
+        git.tag("1.0.0");
+        git.commit("Second");
+        git.tag("2.0.0-alpha.1");
+        git.commit("Third");
+        git.tag("2.0.0-beta.1");
+        git.commit("Fourth");
+        git.tag("2.0.0-rc.1");
+        git.commit("Fifth");
+
+        assertOldVersions(gradle, "[1.0.0]");
+    }
+
+    @Test
     void when_the_initial_commit_is_0_0_0_ignore_it_as_its_the_first_unpublished_release(
             GradleInvoker gradle, Git git) {
         git.commit("Initial");

--- a/src/test/java/com/palantir/gradle/revapi/RevapiTest.java
+++ b/src/test/java/com/palantir/gradle/revapi/RevapiTest.java
@@ -188,6 +188,23 @@ class RevapiTest {
         }
 
         @Test
+        void skips_revapi_tasks_when_all_explicit_old_versions_are_filtered_out(
+                GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                revapi {
+                    oldGroup = 'org.revapi'
+                    oldName = 'revapi'
+                    oldVersions = ['0.11.1-beta']
+                    oldVersionPattern = '[0-9]+[.][0-9]+[.][0-9]+'
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("revapi").buildsSuccessfully();
+            assertThat(result).task(":revapiAnalyze").skipped();
+            assertThat(result).task(":revapi").skipped();
+        }
+
+        @Test
         void handles_the_output_of_extra_source_sets_being_added_to_compile_configuration(
                 GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""


### PR DESCRIPTION
## Before this PR

Projects which publish alpha, beta, or release candidate versions cannot exclude those versions when Revapi selects an old API. This can require accepting the same intentional breaks repeatedly during a prerelease cycle.

Fixes #630. Supersedes #631.

## After this PR

==COMMIT_MSG==
Add an `oldVersionPattern` property which selects candidate old versions using a regular expression. This mirrors the Revapi Maven plugin's `versionFormat` support for excluding prerelease versions.

Git tags are filtered before the three-candidate limit, allowing Revapi to find an older stable release even when several prerelease tags are newer. The pattern also applies to versions configured explicitly through `oldVersion` or `oldVersions`.
==COMMIT_MSG==

For example:

```gradle
revapi {
    oldVersionPattern = '[0-9]+[.][0-9]+[.][0-9]+'
}
```

## Possible downsides?

An invalid regular expression will fail the build. If the pattern excludes every candidate, Revapi analysis is skipped in the same way as configuring an empty `oldVersions` list.
