### PR TITLE
Ignore release candidates when selecting the previous API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ among projects.
 ## Configuration
 
 `gradle-revapi` should work out of the box for most uses cases once applied. By default it compares against the previous
-version of the jar from the project it is applied in by finding the last tag using `git describe`. However, if you need
-to need to override the artifact to compare against, you can do so:
+version of the jar from the project it is applied in by finding the last non-release-candidate tag using `git describe`.
+However, if you need to need to override the artifact to compare against, you can do so:
 
 ```gradle
 revapi {

--- a/src/main/java/com/palantir/gradle/revapi/GitOperations.java
+++ b/src/main/java/com/palantir/gradle/revapi/GitOperations.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.revapi;
 import com.palantir.gradle.gitversion.GitInvoker;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Nested;
@@ -33,13 +34,16 @@ import org.gradle.api.tasks.Nested;
  *   <li>Run {@code git describe --tags --abbrev=0} to find the nearest reachable tag from that commit.
  *   <li>If the tag is the sentinel {@code 0.0.0}, only accept it when the commit has a parent (filters out the
  *       synthetic root-commit tag used when no real releases exist yet).
- *   <li>Feed that tag back in as the next ref and repeat, collecting up to {@link #TAGS_TO_RETURN} tags.
- *   <li>Strip a leading {@code v} from each tag before returning.
+ *   <li>Feed that tag back in as the next ref and repeat.
+ *   <li>Strip leading {@code v} prefixes, discard release candidates, and return up to
+ *       {@link #TAGS_TO_RETURN} tags.
  * </ol>
  */
 public abstract class GitOperations {
 
     private static final int TAGS_TO_RETURN = 3;
+    private static final Pattern RELEASE_CANDIDATE =
+            Pattern.compile("(?:^|[._-])rc(?:[._-]?\\d+)?(?:$|[._+-])", Pattern.CASE_INSENSITIVE);
 
     @Nested
     protected abstract GitInvoker getGitInvoker();
@@ -50,8 +54,9 @@ public abstract class GitOperations {
                                 seed,
                                 Objects::nonNull,
                                 ref -> previousGitTagFromRef(ref).getOrNull())
-                        .limit(TAGS_TO_RETURN)
                         .map(GitOperations::stripVFromTag)
+                        .filter(tag -> !RELEASE_CANDIDATE.matcher(tag).find())
+                        .limit(TAGS_TO_RETURN)
                         .toList())
                 .orElse(List.of());
     }

--- a/src/test/java/com/palantir/gradle/revapi/GitOperationsTest.java
+++ b/src/test/java/com/palantir/gradle/revapi/GitOperationsTest.java
@@ -86,6 +86,21 @@ class GitOperationsTest {
     }
 
     @Test
+    void ignores_release_candidate_tags(GradleInvoker gradle, Git git) {
+        git.commit("Stable");
+        git.tag("1.0.0");
+        git.commit("RC 1");
+        git.tag("1.1.0-rc1");
+        git.commit("RC 2");
+        git.tag("1.1.0-rc2");
+        git.commit("RC 3");
+        git.tag("1.1.0-rc3");
+        git.commit("Current");
+
+        assertOldVersions(gradle, "[1.0.0]");
+    }
+
+    @Test
     void when_the_initial_commit_is_0_0_0_ignore_it_as_its_the_first_unpublished_release(
             GradleInvoker gradle, Git git) {
         git.commit("Initial");


### PR DESCRIPTION
> [!NOTE]
> This is a smaller alternative to #805.

## Before this PR

`GitOperations`, introduced in #714, selected previous APIs from the nearest Git tags. Given `1.0.0` followed by `1.1.0-rc1`, it selected the temporary release candidate as the compatibility baseline.

## After this PR

==COMMIT_MSG==
==COMMIT_MSG==

`gradle-revapi` skips release-candidate tags while walking Git history. It continues past RC tags before applying the existing three-version limit, so the latest stable release remains the compatibility baseline.

## Testing

A `GitOperationsTest` fixture covers a stable release followed by three RC tags. It passes on Gradle 8.14.5 and 9.3.1.

## Possible downsides?

Projects that intentionally compare against a release candidate must configure `oldVersion` explicitly.

## Are Docs needed?

The README now documents release-candidate exclusion.